### PR TITLE
[TASK-P68] 추가 이슈 발견 - LifeOver 로직에서 GameOver가 이어지도록 수정

### DIFF
--- a/RunInBoots/Assets/Scripts/States/StageState.cs
+++ b/RunInBoots/Assets/Scripts/States/StageState.cs
@@ -157,8 +157,15 @@ public class StageState : IGameState
     private void LifeOver()
     {
         _lifeCount--;
-        
         _userData.UpdateLives(_lifeCount);
+
+        // GAME OVER IF LIFE IS 0
+        if (_lifeCount <=0)
+        {
+            ClearCatnipUI();
+            GameManager.Instance.GameOver();
+            return;
+        }
 
         SceneManager.sceneLoaded += OnCurrentSceneLoaded;
         SceneLoader.LoadCurrentScene();
@@ -189,18 +196,7 @@ public class StageState : IGameState
             _accumulativeTime += _timeLimit - _remainingTime;
             _remainingTime = _timeLimit;
         }
-
-        if (_lifeCount > 1)
-        {
-            LifeOver();
-        }
-        else
-        {
-            _lifeCount = 9;
-            ClearCatnipUI();
-
-            GameManager.Instance.GameOver();
-        }
+        LifeOver();
     }
 
     /******************** 플레이어 Spawn 관련 함수들 ********************/


### PR DESCRIPTION
## PR Description
타이틀 씬 연결 테스트 중 이슈 발견, 전투 모듈 사망 시 GameOver 처리가 안 됨.
수정 사항 : LifeOver 처리에서 목숨 0 도달 시 GameOver 처리하도록 로직 위치 이동
### Changes Included
- [ ] Added new feature(s)
- [x] Fixed identified bug(s)
- [ ] Updated relevant documentation
### Screenshots (if UI changes were made)
Attach screenshots or GIFs of any visual changes. (Only for frontend-related changes)
### Notes for Reviewer
Any specific instructions or points to be considered by the reviewer.
---
## Reviewer Checklist
- [ ] Code is written in clean, maintainable, and idiomatic form.
- [ ] Automated test coverage is adequate.
- [ ] All existing tests pass.
- [ ] Manual testing has been performed to ensure the PR works as expected.
- [ ] Code review comments have been addressed or clarified.
---
## Additional Comments

