### PR TITLE
[ISSUE-B17] Pipe 스폰 위치 오프셋 제거

### DIFF
--- a/RunInBoots/Assets/Scripts/Objects/Pipe.cs
+++ b/RunInBoots/Assets/Scripts/Objects/Pipe.cs
@@ -2,12 +2,16 @@ using TMPro;
 using UnityEngine;
 using UnityEngine.Events;
 using UnityEngine.SceneManagement;
+using System.Collections;
 
 public class Pipe : Interactable
 {
     public int targetIndex;
     public int pipeID;
     public int targetPipeID;
+
+    private Collider pipeCollider;
+
 
     public override void Initialize()
     {
@@ -16,12 +20,25 @@ public class Pipe : Interactable
 
     public void SpawnPlayerByPipe()
     {
+        pipeCollider = GetComponent<Collider>();
+        StartCoroutine(DisableCollisionTemporarily());
+
         StageState currentStageState = GameManager.Instance.GetCurrentStageState();
-        Vector3 targetPosition = transform.position + Vector3.right * 1.5f;
+        Vector3 targetPosition = transform.position;
         currentStageState.SpawnPlayer(targetPosition);
         currentStageState.UpdateRespawnPosition(targetPosition, false);
     }
-    
+
+    private IEnumerator DisableCollisionTemporarily()
+    {
+        if (pipeCollider != null)
+        {
+            pipeCollider.enabled = false; // Collider 비활성화
+            yield return new WaitForSeconds(1f); // 1초 대기
+            pipeCollider.enabled = true; // Collider 다시 활성화
+        }
+    }
+
     protected override void OnInteract(GameObject interactor)
     {
         ProducingEvent pipeInteractionEvent = new AnimatorEvent(null);

--- a/RunInBoots/Assets/Scripts/States/StageState.cs
+++ b/RunInBoots/Assets/Scripts/States/StageState.cs
@@ -332,7 +332,6 @@ public class StageState : IGameState
             Debug.LogError("���� ������ target Pipe�� ã�� �� �����ϴ�.");
         }
         UpdateStageMapSize();
-        Debug.LogError($"gridSize: {gridSizeX}, {gridSizeY}");
         SceneManager.sceneLoaded -= OnSceneLoaded;
     }
 


### PR DESCRIPTION
# PR Title
[ISSUE-B17] Pipe 스폰 위치 오프셋 제거
## Related Issue(s)
ISSUE-B17

## PR Description
Pipe spawn 위치 조정
Pipe로 spawn 한 뒤 1초간 Pipe 비활성화

### Changes Included
Pipe 이용 후 1초간 해당 Pipe 비활성화됨.
---
## Additional Comments
BattleModule의 무적 시스템에서 프레임 밀림 현상 발생하여 단순히 Pipe spawn position을 조정한 경우 두 pipe를 무한히 이동하는 현상 발생.
이를 해결하기 위해 1초간 Pipe collider 비활성화함.
linter.yml:
---
name: Lint
on: # yamllint disable-line rule:truthy
  push: null
  pull_request: null
permissions: {}
jobs:
  build:
    name: Lint
    runs-on: ubuntu-latest
    permissions:
      contents: read
      packages: read
      # To report GitHub Actions status checks
      statuses: write
    steps:
      - name: Checkout code
        uses: actions/checkout@v4
        with:
          # super-linter needs the full git history to get the
          # list of files that changed across commits
          fetch-depth: 0
      - name: Super-linter
        uses: super-linter/super-linter@v7.1.0 # x-release-please-version
        env:
          # To report GitHub Actions status checks
          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
