### PR TITLE
[ISSUE-B22] infinite_pipe_movement_after_death

### DIFF
--- a/RunInBoots/Assets/Scripts/Managers/GameManager.cs
+++ b/RunInBoots/Assets/Scripts/Managers/GameManager.cs
@@ -195,6 +195,11 @@ public class GameManager : MonoSingleton<GameManager>
         AddEvent(catnipEvent);
     }
 
+    public void StartGameManagerCoroutine(IEnumerator coroutine)
+    {
+        StartCoroutine(coroutine);
+    }
+
     // Event Queue
     public void AddEvent(ProducingEvent producingEvent)
     {

--- a/RunInBoots/Assets/Scripts/Objects/Pipe.cs
+++ b/RunInBoots/Assets/Scripts/Objects/Pipe.cs
@@ -20,8 +20,6 @@ public class Pipe : Interactable
 
     public void SpawnPlayerByPipe()
     {
-        StartCoroutine(DisableCollisionTemporarily());
-
         StageState currentStageState = GameManager.Instance.GetCurrentStageState();
         Vector3 targetPosition = transform.position;
         currentStageState.SpawnPlayer(targetPosition);

--- a/RunInBoots/Assets/Scripts/Objects/Pipe.cs
+++ b/RunInBoots/Assets/Scripts/Objects/Pipe.cs
@@ -20,7 +20,6 @@ public class Pipe : Interactable
 
     public void SpawnPlayerByPipe()
     {
-        pipeCollider = GetComponent<Collider>();
         StartCoroutine(DisableCollisionTemporarily());
 
         StageState currentStageState = GameManager.Instance.GetCurrentStageState();
@@ -29,13 +28,16 @@ public class Pipe : Interactable
         currentStageState.UpdateRespawnPosition(targetPosition, false);
     }
 
-    private IEnumerator DisableCollisionTemporarily()
+    public IEnumerator DisableCollisionTemporarily()
     {
+        pipeCollider = GetComponent<Collider>();
         if (pipeCollider != null)
         {
+            Debug.LogWarning($"Disabling Pipe {pipeID} Collider...");
             pipeCollider.enabled = false; // Collider 비활성화
             yield return new WaitForSeconds(1f); // 1초 대기
             pipeCollider.enabled = true; // Collider 다시 활성화
+            Debug.LogWarning($"Pipe {pipeID} Collider reenabled.");
         }
     }
 

--- a/RunInBoots/Assets/Scripts/States/StageState.cs
+++ b/RunInBoots/Assets/Scripts/States/StageState.cs
@@ -8,7 +8,7 @@ using TMPro;
 using UnityEngine.Rendering.Universal;
 using Newtonsoft.Json;
 using System.IO;
-
+using System.Collections;
 
 
 public class StageState : IGameState
@@ -276,6 +276,9 @@ public class StageState : IGameState
     {
         Debug.LogWarning($"Spawning player at {position}");
         GameObject player = GameObject.FindWithTag("Player");
+
+        DisablePipeColliderTemporarilyIfExists(position);
+
         if (player == null)
         {
             Debug.Log($"Player spawned : {position}");
@@ -294,6 +297,22 @@ public class StageState : IGameState
                 currentHatType = player.GetComponent<CamouflageModule>().GetCurrentHatType(); 
             });
         player.GetComponent<CamouflageModule>().Initialize(currentHatType);
+    }
+
+    private void DisablePipeColliderTemporarilyIfExists(Vector3 position)
+    {
+        // 리스폰 위치 근처에 Pipe가 있는지 확인
+        Collider[] colliders = Physics.OverlapSphere(position, 1.0f); // 반경 1.0f 탐색
+        foreach (var collider in colliders)
+        {
+            Pipe pipe = collider.GetComponent<Pipe>();
+            if (pipe != null)
+            {
+                Debug.LogWarning($"{pipe.pipeID} pipe 리스폰 떄 비활성화");
+                GameManager.Instance.StartGameManagerCoroutine(pipe.DisableCollisionTemporarily()); return;
+                return;
+            }
+        }
     }
 
     private void SpawnPlayerAtStartPoint()


### PR DESCRIPTION
# [ISSUE-B22] infinite_pipe_movement_after_death
## Related Issue(s)
ISSUE-B22
## PR Description
StageState에서 죽음으로 인해 Pipe에서 리스폰 시 pipe가 1초간 작동하지 않도록 변경
### Changes Included
- SpawnPlayer에서 pipe 비활성화를 한번에 처리하도록 변경
- 리스폰 / pipe에 의한 스폰 구분 없이 스폰 장소 주변 1.0f 반경에 pipe 존재하면  해당 pipe 1초간 비활성화 하도록 변경함.
---
## Additional Comments
process.
linter.yml:
---
name: Lint
on: # yamllint disable-line rule:truthy
  push: null
  pull_request: null
permissions: {}
jobs:
  build:
    name: Lint
    runs-on: ubuntu-latest
    permissions:
      contents: read
      packages: read
      # To report GitHub Actions status checks
      statuses: write
    steps:
      - name: Checkout code
        uses: actions/checkout@v4
        with:
          # super-linter needs the full git history to get the
          # list of files that changed across commits
          fetch-depth: 0
      - name: Super-linter
        uses: super-linter/super-linter@v7.1.0 # x-release-please-version
        env:
          # To report GitHub Actions status checks
          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
