### PR TITLE
[ISSUE-B24] 집게 버그 -> 콜라이더 크기 0이면 콜라이더 비활성화하도록 수정

### DIFF
--- a/RunInBoots/Assets/Scripts/UnitModules/ActionSystem.cs
+++ b/RunInBoots/Assets/Scripts/UnitModules/ActionSystem.cs
@@ -92,6 +92,7 @@ public class ActionSystem : MonoBehaviour
         currentCouroutine = StartCoroutine(ChangeColliderSize(targetSize, currentAction.TransitionDuration));
     }
 
+    WaitForFixedUpdate waitForFixedUpdate = new WaitForFixedUpdate();
     IEnumerator ChangeColliderSize(Vector3 newSize, float time)
     {
         Vector3 startSize = coll.size;
@@ -101,12 +102,13 @@ public class ActionSystem : MonoBehaviour
         {
             coll.size = Vector3.Lerp(startSize, newSize, elapsedTime / time);
             coll.center = new Vector3(0, coll.size.y / 2, 0);
-            elapsedTime += Time.deltaTime;
-            yield return null;
+            elapsedTime += Time.fixedDeltaTime;
+            yield return waitForFixedUpdate;
         }
 
         // Ensure the final size is set exactly
         coll.size = newSize;
+        coll.enabled = newSize.x > 0 && newSize.y > 0;
         currentCouroutine = null;
     }
     #endregion


### PR DESCRIPTION


# PR Title [Descriptive title summarizing the change]
집게 버그 -> 콜라이더 크기 0이면 콜라이더 비활성화하도록 수정
## Related Issue(s)
B24
## PR Description
집게 비활성화 시 사이즈 (0,0)짜리 콜라이더로 변경시켰으나, 해당 상태서 충돌 이벤트 발생 확인 크기가 없는 콜라이더는 비활성화하도록 ActionSystem 수정
### Changes Included
- [ ] Added new feature(s)
- [x] Fixed identified bug(s)
- [ ] Updated relevant documentation
### Screenshots (if UI changes were made)
Attach screenshots or GIFs of any visual changes. (Only for frontend-related changes)
### Notes for Reviewer
Any specific instructions or points to be considered by the reviewer.
---
## Reviewer Checklist
- [ ] Code is written in clean, maintainable, and idiomatic form.
- [ ] Automated test coverage is adequate.
- [ ] All existing tests pass.
- [ ] Manual testing has been performed to ensure the PR works as expected.
- [ ] Code review comments have been addressed or clarified.
---