### PR TITLE
아웃게임 씬 개선

### DIFF
--- a/RunInBoots/Assets/Resources/TitleObject.meta
+++ b/RunInBoots/Assets/Resources/TitleObject.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 195db6585cc8b294d94a9ddf79b9065c
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/RunInBoots/Assets/Resources/TitleObject/CatObject.prefab
+++ b/RunInBoots/Assets/Resources/TitleObject/CatObject.prefab
@@ -1,0 +1,171 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &5287369822939886713
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5287369822939886715}
+  m_Layer: 0
+  m_Name: CatObject
+  m_TagString: Player
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &5287369822939886715
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5287369822939886713}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 6749640492942175727}
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1001 &6494528457984461316
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 5287369822939886715}
+    m_Modifications:
+    - target: {fileID: -8679921383154817045, guid: 1c47b6c693def49b286d7bd68991451c,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 1c47b6c693def49b286d7bd68991451c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 1c47b6c693def49b286d7bd68991451c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 1c47b6c693def49b286d7bd68991451c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 1c47b6c693def49b286d7bd68991451c,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 1c47b6c693def49b286d7bd68991451c,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 1c47b6c693def49b286d7bd68991451c,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 1c47b6c693def49b286d7bd68991451c,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 1c47b6c693def49b286d7bd68991451c,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 1c47b6c693def49b286d7bd68991451c,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 1c47b6c693def49b286d7bd68991451c,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 1c47b6c693def49b286d7bd68991451c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 1c47b6c693def49b286d7bd68991451c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 90
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 1c47b6c693def49b286d7bd68991451c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8141192513427556360, guid: 1c47b6c693def49b286d7bd68991451c,
+        type: 3}
+      propertyPath: m_Enabled
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -150009337949190703, guid: 1c47b6c693def49b286d7bd68991451c,
+        type: 3}
+      propertyPath: m_Enabled
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 919132149155446097, guid: 1c47b6c693def49b286d7bd68991451c,
+        type: 3}
+      propertyPath: m_Name
+      value: Cat-BothHats
+      objectReference: {fileID: 0}
+    - target: {fileID: 2232297421615071699, guid: 1c47b6c693def49b286d7bd68991451c,
+        type: 3}
+      propertyPath: m_IsActive
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8699652204047898494, guid: 1c47b6c693def49b286d7bd68991451c,
+        type: 3}
+      propertyPath: m_IsActive
+      value: 1
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 1c47b6c693def49b286d7bd68991451c, type: 3}
+--- !u!1 &6260103438782789461 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 919132149155446097, guid: 1c47b6c693def49b286d7bd68991451c,
+    type: 3}
+  m_PrefabInstance: {fileID: 6494528457984461316}
+  m_PrefabAsset: {fileID: 0}
+--- !u!95 &463189576518754613
+Animator:
+  serializedVersion: 5
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6260103438782789461}
+  m_Enabled: 1
+  m_Avatar: {fileID: 0}
+  m_Controller: {fileID: 9100000, guid: 0e0baf0339549374f9e78cc244b76037, type: 2}
+  m_CullingMode: 0
+  m_UpdateMode: 0
+  m_ApplyRootMotion: 0
+  m_LinearVelocityBlending: 0
+  m_StabilizeFeet: 0
+  m_WarningMessage: 
+  m_HasTransformHierarchy: 1
+  m_AllowConstantClipSamplingOptimization: 1
+  m_KeepAnimatorStateOnDisable: 0
+  m_WriteDefaultValuesOnDisable: 0
+--- !u!4 &6749640492942175727 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: -8679921383154817045, guid: 1c47b6c693def49b286d7bd68991451c,
+    type: 3}
+  m_PrefabInstance: {fileID: 6494528457984461316}
+  m_PrefabAsset: {fileID: 0}

--- a/RunInBoots/Assets/Resources/TitleObject/CatObject.prefab.meta
+++ b/RunInBoots/Assets/Resources/TitleObject/CatObject.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: ad35fbb3da8250443a319e23cbe387b7
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/RunInBoots/Assets/Resources/TitleObject/ClawObject.prefab
+++ b/RunInBoots/Assets/Resources/TitleObject/ClawObject.prefab
@@ -1,0 +1,1291 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &3992559241687619214
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3992559241687619215}
+  m_Layer: 0
+  m_Name: ClawObject
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &3992559241687619215
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3992559241687619214}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 6.75, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 6739448681519347931}
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1001 &265298112320683722
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 3992559241687619215}
+    m_Modifications:
+    - target: {fileID: 209589519165535746, guid: 8ea9ec22169184ecca648dffc6de559b,
+        type: 3}
+      propertyPath: m_Layer
+      value: 4
+      objectReference: {fileID: 0}
+    - target: {fileID: 316826191502556592, guid: 8ea9ec22169184ecca648dffc6de559b,
+        type: 3}
+      propertyPath: m_Layer
+      value: 4
+      objectReference: {fileID: 0}
+    - target: {fileID: 399052403823147101, guid: 8ea9ec22169184ecca648dffc6de559b,
+        type: 3}
+      propertyPath: m_Layer
+      value: 4
+      objectReference: {fileID: 0}
+    - target: {fileID: 475269179350400673, guid: 8ea9ec22169184ecca648dffc6de559b,
+        type: 3}
+      propertyPath: m_Layer
+      value: 4
+      objectReference: {fileID: 0}
+    - target: {fileID: 608385849289511251, guid: 8ea9ec22169184ecca648dffc6de559b,
+        type: 3}
+      propertyPath: m_Layer
+      value: 4
+      objectReference: {fileID: 0}
+    - target: {fileID: 775059194852456017, guid: 8ea9ec22169184ecca648dffc6de559b,
+        type: 3}
+      propertyPath: m_Layer
+      value: 4
+      objectReference: {fileID: 0}
+    - target: {fileID: 1038394651964861763, guid: 8ea9ec22169184ecca648dffc6de559b,
+        type: 3}
+      propertyPath: m_Layer
+      value: 4
+      objectReference: {fileID: 0}
+    - target: {fileID: 1139067265257388201, guid: 8ea9ec22169184ecca648dffc6de559b,
+        type: 3}
+      propertyPath: m_Layer
+      value: 4
+      objectReference: {fileID: 0}
+    - target: {fileID: 1185036029279468507, guid: 8ea9ec22169184ecca648dffc6de559b,
+        type: 3}
+      propertyPath: m_Layer
+      value: 4
+      objectReference: {fileID: 0}
+    - target: {fileID: 1371152410767735750, guid: 8ea9ec22169184ecca648dffc6de559b,
+        type: 3}
+      propertyPath: m_Layer
+      value: 4
+      objectReference: {fileID: 0}
+    - target: {fileID: 1406013613951124580, guid: 8ea9ec22169184ecca648dffc6de559b,
+        type: 3}
+      propertyPath: m_Layer
+      value: 4
+      objectReference: {fileID: 0}
+    - target: {fileID: 1521225819567843653, guid: 8ea9ec22169184ecca648dffc6de559b,
+        type: 3}
+      propertyPath: m_Layer
+      value: 4
+      objectReference: {fileID: 0}
+    - target: {fileID: 1549454445400878742, guid: 8ea9ec22169184ecca648dffc6de559b,
+        type: 3}
+      propertyPath: m_Layer
+      value: 4
+      objectReference: {fileID: 0}
+    - target: {fileID: 1555012766245354648, guid: 8ea9ec22169184ecca648dffc6de559b,
+        type: 3}
+      propertyPath: m_Layer
+      value: 4
+      objectReference: {fileID: 0}
+    - target: {fileID: 1749406485269797171, guid: 8ea9ec22169184ecca648dffc6de559b,
+        type: 3}
+      propertyPath: m_Layer
+      value: 4
+      objectReference: {fileID: 0}
+    - target: {fileID: 2128285116198500478, guid: 8ea9ec22169184ecca648dffc6de559b,
+        type: 3}
+      propertyPath: m_Layer
+      value: 4
+      objectReference: {fileID: 0}
+    - target: {fileID: 2446849177903403494, guid: 8ea9ec22169184ecca648dffc6de559b,
+        type: 3}
+      propertyPath: m_Layer
+      value: 4
+      objectReference: {fileID: 0}
+    - target: {fileID: 2501939581960801412, guid: 8ea9ec22169184ecca648dffc6de559b,
+        type: 3}
+      propertyPath: m_Layer
+      value: 4
+      objectReference: {fileID: 0}
+    - target: {fileID: 3083140410982875337, guid: 8ea9ec22169184ecca648dffc6de559b,
+        type: 3}
+      propertyPath: m_Layer
+      value: 4
+      objectReference: {fileID: 0}
+    - target: {fileID: 3124899230090769104, guid: 8ea9ec22169184ecca648dffc6de559b,
+        type: 3}
+      propertyPath: m_Layer
+      value: 4
+      objectReference: {fileID: 0}
+    - target: {fileID: 3273741775192610721, guid: 8ea9ec22169184ecca648dffc6de559b,
+        type: 3}
+      propertyPath: m_Layer
+      value: 4
+      objectReference: {fileID: 0}
+    - target: {fileID: 3327627095810240316, guid: 8ea9ec22169184ecca648dffc6de559b,
+        type: 3}
+      propertyPath: m_Layer
+      value: 4
+      objectReference: {fileID: 0}
+    - target: {fileID: 3344899189440908929, guid: 8ea9ec22169184ecca648dffc6de559b,
+        type: 3}
+      propertyPath: m_Layer
+      value: 4
+      objectReference: {fileID: 0}
+    - target: {fileID: 3381695247045412577, guid: 8ea9ec22169184ecca648dffc6de559b,
+        type: 3}
+      propertyPath: m_Layer
+      value: 4
+      objectReference: {fileID: 0}
+    - target: {fileID: 4314521799038386901, guid: 8ea9ec22169184ecca648dffc6de559b,
+        type: 3}
+      propertyPath: m_Layer
+      value: 4
+      objectReference: {fileID: 0}
+    - target: {fileID: 4356400395012246826, guid: 8ea9ec22169184ecca648dffc6de559b,
+        type: 3}
+      propertyPath: m_Layer
+      value: 4
+      objectReference: {fileID: 0}
+    - target: {fileID: 4547130564047855781, guid: 8ea9ec22169184ecca648dffc6de559b,
+        type: 3}
+      propertyPath: m_Layer
+      value: 4
+      objectReference: {fileID: 0}
+    - target: {fileID: 5087405727786040132, guid: 8ea9ec22169184ecca648dffc6de559b,
+        type: 3}
+      propertyPath: m_Layer
+      value: 4
+      objectReference: {fileID: 0}
+    - target: {fileID: 5436846202279502925, guid: 8ea9ec22169184ecca648dffc6de559b,
+        type: 3}
+      propertyPath: m_Layer
+      value: 4
+      objectReference: {fileID: 0}
+    - target: {fileID: 5458607135791635361, guid: 8ea9ec22169184ecca648dffc6de559b,
+        type: 3}
+      propertyPath: m_Layer
+      value: 4
+      objectReference: {fileID: 0}
+    - target: {fileID: 5739021114002807691, guid: 8ea9ec22169184ecca648dffc6de559b,
+        type: 3}
+      propertyPath: m_Layer
+      value: 4
+      objectReference: {fileID: 0}
+    - target: {fileID: 5949499365539316429, guid: 8ea9ec22169184ecca648dffc6de559b,
+        type: 3}
+      propertyPath: m_Layer
+      value: 4
+      objectReference: {fileID: 0}
+    - target: {fileID: 6494003774844422873, guid: 8ea9ec22169184ecca648dffc6de559b,
+        type: 3}
+      propertyPath: m_Layer
+      value: 4
+      objectReference: {fileID: 0}
+    - target: {fileID: 6785187290413778449, guid: 8ea9ec22169184ecca648dffc6de559b,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6785187290413778449, guid: 8ea9ec22169184ecca648dffc6de559b,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6785187290413778449, guid: 8ea9ec22169184ecca648dffc6de559b,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -4
+      objectReference: {fileID: 0}
+    - target: {fileID: 6785187290413778449, guid: 8ea9ec22169184ecca648dffc6de559b,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6785187290413778449, guid: 8ea9ec22169184ecca648dffc6de559b,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6785187290413778449, guid: 8ea9ec22169184ecca648dffc6de559b,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6785187290413778449, guid: 8ea9ec22169184ecca648dffc6de559b,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6785187290413778449, guid: 8ea9ec22169184ecca648dffc6de559b,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6785187290413778449, guid: 8ea9ec22169184ecca648dffc6de559b,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6785187290413778449, guid: 8ea9ec22169184ecca648dffc6de559b,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6785187290413778449, guid: 8ea9ec22169184ecca648dffc6de559b,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6909643327718083048, guid: 8ea9ec22169184ecca648dffc6de559b,
+        type: 3}
+      propertyPath: m_Layer
+      value: 4
+      objectReference: {fileID: 0}
+    - target: {fileID: 7267374563911469446, guid: 8ea9ec22169184ecca648dffc6de559b,
+        type: 3}
+      propertyPath: m_Layer
+      value: 4
+      objectReference: {fileID: 0}
+    - target: {fileID: 7323105074099722889, guid: 8ea9ec22169184ecca648dffc6de559b,
+        type: 3}
+      propertyPath: m_Layer
+      value: 4
+      objectReference: {fileID: 0}
+    - target: {fileID: 7376584694639092721, guid: 8ea9ec22169184ecca648dffc6de559b,
+        type: 3}
+      propertyPath: m_Layer
+      value: 4
+      objectReference: {fileID: 0}
+    - target: {fileID: 7447201836327560371, guid: 8ea9ec22169184ecca648dffc6de559b,
+        type: 3}
+      propertyPath: m_Layer
+      value: 4
+      objectReference: {fileID: 0}
+    - target: {fileID: 7627125375323587668, guid: 8ea9ec22169184ecca648dffc6de559b,
+        type: 3}
+      propertyPath: m_Layer
+      value: 4
+      objectReference: {fileID: 0}
+    - target: {fileID: 7845605378465914158, guid: 8ea9ec22169184ecca648dffc6de559b,
+        type: 3}
+      propertyPath: m_Layer
+      value: 4
+      objectReference: {fileID: 0}
+    - target: {fileID: 7858038849765630973, guid: 8ea9ec22169184ecca648dffc6de559b,
+        type: 3}
+      propertyPath: m_Layer
+      value: 4
+      objectReference: {fileID: 0}
+    - target: {fileID: 7893780147703259798, guid: 8ea9ec22169184ecca648dffc6de559b,
+        type: 3}
+      propertyPath: m_Layer
+      value: 4
+      objectReference: {fileID: 0}
+    - target: {fileID: 7929321993305537773, guid: 8ea9ec22169184ecca648dffc6de559b,
+        type: 3}
+      propertyPath: m_Name
+      value: Obstacle_Clamp
+      objectReference: {fileID: 0}
+    - target: {fileID: 8004046723261055702, guid: 8ea9ec22169184ecca648dffc6de559b,
+        type: 3}
+      propertyPath: m_Layer
+      value: 4
+      objectReference: {fileID: 0}
+    - target: {fileID: 8368850414583581786, guid: 8ea9ec22169184ecca648dffc6de559b,
+        type: 3}
+      propertyPath: m_Layer
+      value: 4
+      objectReference: {fileID: 0}
+    - target: {fileID: 8659886583826175853, guid: 8ea9ec22169184ecca648dffc6de559b,
+        type: 3}
+      propertyPath: m_Layer
+      value: 4
+      objectReference: {fileID: 0}
+    - target: {fileID: 8763055726955699768, guid: 8ea9ec22169184ecca648dffc6de559b,
+        type: 3}
+      propertyPath: m_Layer
+      value: 4
+      objectReference: {fileID: 0}
+    - target: {fileID: 9160766828311771941, guid: 8ea9ec22169184ecca648dffc6de559b,
+        type: 3}
+      propertyPath: m_Layer
+      value: 4
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 8ea9ec22169184ecca648dffc6de559b, type: 3}
+--- !u!1 &700735634638494194 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 727054686353450808, guid: 8ea9ec22169184ecca648dffc6de559b,
+    type: 3}
+  m_PrefabInstance: {fileID: 265298112320683722}
+  m_PrefabAsset: {fileID: 0}
+--- !u!54 &479106210660637376
+Rigidbody:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 700735634638494194}
+  serializedVersion: 2
+  m_Mass: 1
+  m_Drag: 0
+  m_AngularDrag: 0.05
+  m_UseGravity: 1
+  m_IsKinematic: 0
+  m_Interpolate: 0
+  m_Constraints: 56
+  m_CollisionDetection: 0
+--- !u!153 &4661629014834883154
+ConfigurableJoint:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 700735634638494194}
+  m_ConnectedBody: {fileID: 5221588937691514605}
+  m_ConnectedArticulationBody: {fileID: 0}
+  m_Anchor: {x: 0, y: 0.5, z: 0}
+  m_Axis: {x: 0, y: 1, z: 0}
+  m_AutoConfigureConnectedAnchor: 1
+  m_ConnectedAnchor: {x: 0, y: 0, z: 0}
+  serializedVersion: 2
+  m_SecondaryAxis: {x: 0, y: 0, z: 1}
+  m_XMotion: 0
+  m_YMotion: 0
+  m_ZMotion: 0
+  m_AngularXMotion: 1
+  m_AngularYMotion: 1
+  m_AngularZMotion: 1
+  m_LinearLimitSpring:
+    spring: 0
+    damper: 0
+  m_LinearLimit:
+    limit: 0
+    bounciness: 0
+    contactDistance: 0
+  m_AngularXLimitSpring:
+    spring: 0
+    damper: 0
+  m_LowAngularXLimit:
+    limit: -30
+    bounciness: 0
+    contactDistance: 0
+  m_HighAngularXLimit:
+    limit: 1
+    bounciness: 0
+    contactDistance: 0
+  m_AngularYZLimitSpring:
+    spring: 0
+    damper: 0
+  m_AngularYLimit:
+    limit: 30
+    bounciness: 0
+    contactDistance: 0
+  m_AngularZLimit:
+    limit: 3
+    bounciness: 0
+    contactDistance: 0
+  m_TargetPosition: {x: 0, y: 0, z: 0}
+  m_TargetVelocity: {x: 0, y: 0, z: 0}
+  m_XDrive:
+    serializedVersion: 3
+    positionSpring: 0
+    positionDamper: 0
+    maximumForce: 3.4028233e+38
+  m_YDrive:
+    serializedVersion: 3
+    positionSpring: 0
+    positionDamper: 0
+    maximumForce: 3.4028233e+38
+  m_ZDrive:
+    serializedVersion: 3
+    positionSpring: 0
+    positionDamper: 0
+    maximumForce: 3.4028233e+38
+  m_TargetRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_TargetAngularVelocity: {x: 0, y: 0, z: 0}
+  m_RotationDriveMode: 0
+  m_AngularXDrive:
+    serializedVersion: 3
+    positionSpring: 500
+    positionDamper: 50
+    maximumForce: 3.4028233e+38
+  m_AngularYZDrive:
+    serializedVersion: 3
+    positionSpring: 0
+    positionDamper: 0
+    maximumForce: 3.4028233e+38
+  m_SlerpDrive:
+    serializedVersion: 3
+    positionSpring: 0
+    positionDamper: 0
+    maximumForce: 3.4028233e+38
+  m_ProjectionMode: 1
+  m_ProjectionDistance: 0.1
+  m_ProjectionAngle: 1
+  m_ConfiguredInWorldSpace: 0
+  m_SwapBodies: 0
+  m_BreakForce: Infinity
+  m_BreakTorque: Infinity
+  m_EnableCollision: 0
+  m_EnablePreprocessing: 1
+  m_MassScale: 1
+  m_ConnectedMassScale: 1
+--- !u!1 &1798352836666239297 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 1971326879591438219, guid: 8ea9ec22169184ecca648dffc6de559b,
+    type: 3}
+  m_PrefabInstance: {fileID: 265298112320683722}
+  m_PrefabAsset: {fileID: 0}
+--- !u!54 &8024100758207399477
+Rigidbody:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1798352836666239297}
+  serializedVersion: 2
+  m_Mass: 1
+  m_Drag: 0
+  m_AngularDrag: 0.05
+  m_UseGravity: 1
+  m_IsKinematic: 0
+  m_Interpolate: 0
+  m_Constraints: 0
+  m_CollisionDetection: 0
+--- !u!153 &497045347573531030
+ConfigurableJoint:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1798352836666239297}
+  m_ConnectedBody: {fileID: 479106210660637376}
+  m_ConnectedArticulationBody: {fileID: 0}
+  m_Anchor: {x: 0, y: 0.5, z: 0}
+  m_Axis: {x: 0, y: 1, z: 0}
+  m_AutoConfigureConnectedAnchor: 1
+  m_ConnectedAnchor: {x: 0, y: 0, z: 0}
+  serializedVersion: 2
+  m_SecondaryAxis: {x: 0, y: 0, z: 1}
+  m_XMotion: 0
+  m_YMotion: 0
+  m_ZMotion: 0
+  m_AngularXMotion: 1
+  m_AngularYMotion: 1
+  m_AngularZMotion: 1
+  m_LinearLimitSpring:
+    spring: 0
+    damper: 0
+  m_LinearLimit:
+    limit: 0
+    bounciness: 0
+    contactDistance: 0
+  m_AngularXLimitSpring:
+    spring: 0
+    damper: 0
+  m_LowAngularXLimit:
+    limit: -30
+    bounciness: 0
+    contactDistance: 0
+  m_HighAngularXLimit:
+    limit: 1
+    bounciness: 0
+    contactDistance: 0
+  m_AngularYZLimitSpring:
+    spring: 0
+    damper: 0
+  m_AngularYLimit:
+    limit: 30
+    bounciness: 0
+    contactDistance: 0
+  m_AngularZLimit:
+    limit: 3
+    bounciness: 0
+    contactDistance: 0
+  m_TargetPosition: {x: 0, y: 0, z: 0}
+  m_TargetVelocity: {x: 0, y: 0, z: 0}
+  m_XDrive:
+    serializedVersion: 3
+    positionSpring: 0
+    positionDamper: 0
+    maximumForce: 3.4028233e+38
+  m_YDrive:
+    serializedVersion: 3
+    positionSpring: 0
+    positionDamper: 0
+    maximumForce: 3.4028233e+38
+  m_ZDrive:
+    serializedVersion: 3
+    positionSpring: 0
+    positionDamper: 0
+    maximumForce: 3.4028233e+38
+  m_TargetRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_TargetAngularVelocity: {x: 0, y: 0, z: 0}
+  m_RotationDriveMode: 0
+  m_AngularXDrive:
+    serializedVersion: 3
+    positionSpring: 500
+    positionDamper: 50
+    maximumForce: 3.4028233e+38
+  m_AngularYZDrive:
+    serializedVersion: 3
+    positionSpring: 0
+    positionDamper: 0
+    maximumForce: 3.4028233e+38
+  m_SlerpDrive:
+    serializedVersion: 3
+    positionSpring: 0
+    positionDamper: 0
+    maximumForce: 3.4028233e+38
+  m_ProjectionMode: 1
+  m_ProjectionDistance: 0.1
+  m_ProjectionAngle: 1
+  m_ConfiguredInWorldSpace: 0
+  m_SwapBodies: 0
+  m_BreakForce: Infinity
+  m_BreakTorque: Infinity
+  m_EnableCollision: 0
+  m_EnablePreprocessing: 1
+  m_MassScale: 1
+  m_ConnectedMassScale: 1
+--- !u!1 &3015388940755864984 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 3059729177018217298, guid: 8ea9ec22169184ecca648dffc6de559b,
+    type: 3}
+  m_PrefabInstance: {fileID: 265298112320683722}
+  m_PrefabAsset: {fileID: 0}
+--- !u!54 &4621650204745094983
+Rigidbody:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3015388940755864984}
+  serializedVersion: 2
+  m_Mass: 1
+  m_Drag: 0
+  m_AngularDrag: 0.05
+  m_UseGravity: 1
+  m_IsKinematic: 0
+  m_Interpolate: 0
+  m_Constraints: 0
+  m_CollisionDetection: 0
+--- !u!153 &1169966667138918987
+ConfigurableJoint:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3015388940755864984}
+  m_ConnectedBody: {fileID: 8256893280453544651}
+  m_ConnectedArticulationBody: {fileID: 0}
+  m_Anchor: {x: 0, y: 0.5, z: 0}
+  m_Axis: {x: 0, y: 1, z: 0}
+  m_AutoConfigureConnectedAnchor: 1
+  m_ConnectedAnchor: {x: 0, y: 0, z: 0}
+  serializedVersion: 2
+  m_SecondaryAxis: {x: 0, y: 0, z: 1}
+  m_XMotion: 0
+  m_YMotion: 0
+  m_ZMotion: 0
+  m_AngularXMotion: 1
+  m_AngularYMotion: 1
+  m_AngularZMotion: 1
+  m_LinearLimitSpring:
+    spring: 0
+    damper: 0
+  m_LinearLimit:
+    limit: 0
+    bounciness: 0
+    contactDistance: 0
+  m_AngularXLimitSpring:
+    spring: 0
+    damper: 0
+  m_LowAngularXLimit:
+    limit: -30
+    bounciness: 0
+    contactDistance: 0
+  m_HighAngularXLimit:
+    limit: 1
+    bounciness: 0
+    contactDistance: 0
+  m_AngularYZLimitSpring:
+    spring: 0
+    damper: 0
+  m_AngularYLimit:
+    limit: 30
+    bounciness: 0
+    contactDistance: 0
+  m_AngularZLimit:
+    limit: 3
+    bounciness: 0
+    contactDistance: 0
+  m_TargetPosition: {x: 0, y: 0, z: 0}
+  m_TargetVelocity: {x: 0, y: 0, z: 0}
+  m_XDrive:
+    serializedVersion: 3
+    positionSpring: 0
+    positionDamper: 0
+    maximumForce: 3.4028233e+38
+  m_YDrive:
+    serializedVersion: 3
+    positionSpring: 0
+    positionDamper: 0
+    maximumForce: 3.4028233e+38
+  m_ZDrive:
+    serializedVersion: 3
+    positionSpring: 0
+    positionDamper: 0
+    maximumForce: 3.4028233e+38
+  m_TargetRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_TargetAngularVelocity: {x: 0, y: 0, z: 0}
+  m_RotationDriveMode: 0
+  m_AngularXDrive:
+    serializedVersion: 3
+    positionSpring: 500
+    positionDamper: 50
+    maximumForce: 3.4028233e+38
+  m_AngularYZDrive:
+    serializedVersion: 3
+    positionSpring: 0
+    positionDamper: 0
+    maximumForce: 3.4028233e+38
+  m_SlerpDrive:
+    serializedVersion: 3
+    positionSpring: 0
+    positionDamper: 0
+    maximumForce: 3.4028233e+38
+  m_ProjectionMode: 1
+  m_ProjectionDistance: 0.1
+  m_ProjectionAngle: 1
+  m_ConfiguredInWorldSpace: 0
+  m_SwapBodies: 0
+  m_BreakForce: Infinity
+  m_BreakTorque: Infinity
+  m_EnableCollision: 0
+  m_EnablePreprocessing: 1
+  m_MassScale: 1
+  m_ConnectedMassScale: 1
+--- !u!1 &3705806336131156714 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 3513700513848357920, guid: 8ea9ec22169184ecca648dffc6de559b,
+    type: 3}
+  m_PrefabInstance: {fileID: 265298112320683722}
+  m_PrefabAsset: {fileID: 0}
+--- !u!54 &5221588937691514605
+Rigidbody:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3705806336131156714}
+  serializedVersion: 2
+  m_Mass: 1
+  m_Drag: 0
+  m_AngularDrag: 0.05
+  m_UseGravity: 0
+  m_IsKinematic: 1
+  m_Interpolate: 0
+  m_Constraints: 126
+  m_CollisionDetection: 0
+--- !u!1 &5802577558470748563 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 5992147818884224857, guid: 8ea9ec22169184ecca648dffc6de559b,
+    type: 3}
+  m_PrefabInstance: {fileID: 265298112320683722}
+  m_PrefabAsset: {fileID: 0}
+--- !u!54 &7644639941302734877
+Rigidbody:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5802577558470748563}
+  serializedVersion: 2
+  m_Mass: 1
+  m_Drag: 0
+  m_AngularDrag: 0.05
+  m_UseGravity: 1
+  m_IsKinematic: 0
+  m_Interpolate: 0
+  m_Constraints: 0
+  m_CollisionDetection: 0
+--- !u!153 &5159017176284357500
+ConfigurableJoint:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5802577558470748563}
+  m_ConnectedBody: {fileID: 1543000946263089575}
+  m_ConnectedArticulationBody: {fileID: 0}
+  m_Anchor: {x: 0, y: 0.5, z: 0}
+  m_Axis: {x: 0, y: 1, z: 0}
+  m_AutoConfigureConnectedAnchor: 1
+  m_ConnectedAnchor: {x: 0, y: 0, z: 0}
+  serializedVersion: 2
+  m_SecondaryAxis: {x: 0, y: 0, z: 1}
+  m_XMotion: 0
+  m_YMotion: 0
+  m_ZMotion: 0
+  m_AngularXMotion: 1
+  m_AngularYMotion: 1
+  m_AngularZMotion: 1
+  m_LinearLimitSpring:
+    spring: 0
+    damper: 0
+  m_LinearLimit:
+    limit: 0
+    bounciness: 0
+    contactDistance: 0
+  m_AngularXLimitSpring:
+    spring: 0
+    damper: 0
+  m_LowAngularXLimit:
+    limit: -30
+    bounciness: 0
+    contactDistance: 0
+  m_HighAngularXLimit:
+    limit: 1
+    bounciness: 0
+    contactDistance: 0
+  m_AngularYZLimitSpring:
+    spring: 0
+    damper: 0
+  m_AngularYLimit:
+    limit: 30
+    bounciness: 0
+    contactDistance: 0
+  m_AngularZLimit:
+    limit: 3
+    bounciness: 0
+    contactDistance: 0
+  m_TargetPosition: {x: 0, y: 0, z: 0}
+  m_TargetVelocity: {x: 0, y: 0, z: 0}
+  m_XDrive:
+    serializedVersion: 3
+    positionSpring: 0
+    positionDamper: 0
+    maximumForce: 3.4028233e+38
+  m_YDrive:
+    serializedVersion: 3
+    positionSpring: 0
+    positionDamper: 0
+    maximumForce: 3.4028233e+38
+  m_ZDrive:
+    serializedVersion: 3
+    positionSpring: 0
+    positionDamper: 0
+    maximumForce: 3.4028233e+38
+  m_TargetRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_TargetAngularVelocity: {x: 0, y: 0, z: 0}
+  m_RotationDriveMode: 0
+  m_AngularXDrive:
+    serializedVersion: 3
+    positionSpring: 500
+    positionDamper: 50
+    maximumForce: 3.4028233e+38
+  m_AngularYZDrive:
+    serializedVersion: 3
+    positionSpring: 0
+    positionDamper: 0
+    maximumForce: 3.4028233e+38
+  m_SlerpDrive:
+    serializedVersion: 3
+    positionSpring: 0
+    positionDamper: 0
+    maximumForce: 3.4028233e+38
+  m_ProjectionMode: 1
+  m_ProjectionDistance: 0.1
+  m_ProjectionAngle: 1
+  m_ConfiguredInWorldSpace: 0
+  m_SwapBodies: 0
+  m_BreakForce: Infinity
+  m_BreakTorque: Infinity
+  m_EnableCollision: 0
+  m_EnablePreprocessing: 1
+  m_MassScale: 1
+  m_ConnectedMassScale: 1
+--- !u!4 &6739448681519347931 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 6785187290413778449, guid: 8ea9ec22169184ecca648dffc6de559b,
+    type: 3}
+  m_PrefabInstance: {fileID: 265298112320683722}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &7996382073793727596 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 7878585870854550182, guid: 8ea9ec22169184ecca648dffc6de559b,
+    type: 3}
+  m_PrefabInstance: {fileID: 265298112320683722}
+  m_PrefabAsset: {fileID: 0}
+--- !u!54 &1543000946263089575
+Rigidbody:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7996382073793727596}
+  serializedVersion: 2
+  m_Mass: 1
+  m_Drag: 0
+  m_AngularDrag: 0.05
+  m_UseGravity: 1
+  m_IsKinematic: 0
+  m_Interpolate: 0
+  m_Constraints: 0
+  m_CollisionDetection: 0
+--- !u!153 &8761518772576070698
+ConfigurableJoint:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7996382073793727596}
+  m_ConnectedBody: {fileID: 8024100758207399477}
+  m_ConnectedArticulationBody: {fileID: 0}
+  m_Anchor: {x: 0, y: 0.5, z: 0}
+  m_Axis: {x: 0, y: 1, z: 0}
+  m_AutoConfigureConnectedAnchor: 1
+  m_ConnectedAnchor: {x: 0, y: 0, z: 0}
+  serializedVersion: 2
+  m_SecondaryAxis: {x: 0, y: 0, z: 1}
+  m_XMotion: 0
+  m_YMotion: 0
+  m_ZMotion: 0
+  m_AngularXMotion: 1
+  m_AngularYMotion: 1
+  m_AngularZMotion: 1
+  m_LinearLimitSpring:
+    spring: 0
+    damper: 0
+  m_LinearLimit:
+    limit: 0
+    bounciness: 0
+    contactDistance: 0
+  m_AngularXLimitSpring:
+    spring: 0
+    damper: 0
+  m_LowAngularXLimit:
+    limit: -30
+    bounciness: 0
+    contactDistance: 0
+  m_HighAngularXLimit:
+    limit: 1
+    bounciness: 0
+    contactDistance: 0
+  m_AngularYZLimitSpring:
+    spring: 0
+    damper: 0
+  m_AngularYLimit:
+    limit: 30
+    bounciness: 0
+    contactDistance: 0
+  m_AngularZLimit:
+    limit: 3
+    bounciness: 0
+    contactDistance: 0
+  m_TargetPosition: {x: 0, y: 0, z: 0}
+  m_TargetVelocity: {x: 0, y: 0, z: 0}
+  m_XDrive:
+    serializedVersion: 3
+    positionSpring: 0
+    positionDamper: 0
+    maximumForce: 3.4028233e+38
+  m_YDrive:
+    serializedVersion: 3
+    positionSpring: 0
+    positionDamper: 0
+    maximumForce: 3.4028233e+38
+  m_ZDrive:
+    serializedVersion: 3
+    positionSpring: 0
+    positionDamper: 0
+    maximumForce: 3.4028233e+38
+  m_TargetRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_TargetAngularVelocity: {x: 0, y: 0, z: 0}
+  m_RotationDriveMode: 0
+  m_AngularXDrive:
+    serializedVersion: 3
+    positionSpring: 500
+    positionDamper: 50
+    maximumForce: 3.4028233e+38
+  m_AngularYZDrive:
+    serializedVersion: 3
+    positionSpring: 0
+    positionDamper: 0
+    maximumForce: 3.4028233e+38
+  m_SlerpDrive:
+    serializedVersion: 3
+    positionSpring: 0
+    positionDamper: 0
+    maximumForce: 3.4028233e+38
+  m_ProjectionMode: 1
+  m_ProjectionDistance: 0.1
+  m_ProjectionAngle: 1
+  m_ConfiguredInWorldSpace: 0
+  m_SwapBodies: 0
+  m_BreakForce: Infinity
+  m_BreakTorque: Infinity
+  m_EnableCollision: 0
+  m_EnablePreprocessing: 1
+  m_MassScale: 1
+  m_ConnectedMassScale: 1
+--- !u!1 &8805144180592550130 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 8763055726955699768, guid: 8ea9ec22169184ecca648dffc6de559b,
+    type: 3}
+  m_PrefabInstance: {fileID: 265298112320683722}
+  m_PrefabAsset: {fileID: 0}
+--- !u!54 &7678273484695181522
+Rigidbody:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8805144180592550130}
+  serializedVersion: 2
+  m_Mass: 1
+  m_Drag: 0
+  m_AngularDrag: 0.05
+  m_UseGravity: 0
+  m_IsKinematic: 0
+  m_Interpolate: 0
+  m_Constraints: 120
+  m_CollisionDetection: 0
+--- !u!65 &4289541606063561205
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8805144180592550130}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 1
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Size: {x: 1, y: 1, z: 1}
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!153 &6449649579316589150
+ConfigurableJoint:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8805144180592550130}
+  m_ConnectedBody: {fileID: 4621650204745094983}
+  m_ConnectedArticulationBody: {fileID: 0}
+  m_Anchor: {x: 0, y: 0.5, z: 0}
+  m_Axis: {x: 0, y: 1, z: 0}
+  m_AutoConfigureConnectedAnchor: 1
+  m_ConnectedAnchor: {x: 0, y: 0, z: 0}
+  serializedVersion: 2
+  m_SecondaryAxis: {x: 0, y: 0, z: 1}
+  m_XMotion: 0
+  m_YMotion: 0
+  m_ZMotion: 0
+  m_AngularXMotion: 1
+  m_AngularYMotion: 1
+  m_AngularZMotion: 1
+  m_LinearLimitSpring:
+    spring: 0
+    damper: 0
+  m_LinearLimit:
+    limit: 0
+    bounciness: 0
+    contactDistance: 0
+  m_AngularXLimitSpring:
+    spring: 0
+    damper: 0
+  m_LowAngularXLimit:
+    limit: -30
+    bounciness: 0
+    contactDistance: 0
+  m_HighAngularXLimit:
+    limit: 1
+    bounciness: 0
+    contactDistance: 0
+  m_AngularYZLimitSpring:
+    spring: 0
+    damper: 0
+  m_AngularYLimit:
+    limit: 30
+    bounciness: 0
+    contactDistance: 0
+  m_AngularZLimit:
+    limit: 3
+    bounciness: 0
+    contactDistance: 0
+  m_TargetPosition: {x: 0, y: 0, z: 0}
+  m_TargetVelocity: {x: 0, y: 0, z: 0}
+  m_XDrive:
+    serializedVersion: 3
+    positionSpring: 0
+    positionDamper: 0
+    maximumForce: 3.4028233e+38
+  m_YDrive:
+    serializedVersion: 3
+    positionSpring: 0
+    positionDamper: 0
+    maximumForce: 3.4028233e+38
+  m_ZDrive:
+    serializedVersion: 3
+    positionSpring: 0
+    positionDamper: 0
+    maximumForce: 3.4028233e+38
+  m_TargetRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_TargetAngularVelocity: {x: 0, y: 0, z: 0}
+  m_RotationDriveMode: 0
+  m_AngularXDrive:
+    serializedVersion: 3
+    positionSpring: 500
+    positionDamper: 50
+    maximumForce: 3.4028233e+38
+  m_AngularYZDrive:
+    serializedVersion: 3
+    positionSpring: 0
+    positionDamper: 0
+    maximumForce: 3.4028233e+38
+  m_SlerpDrive:
+    serializedVersion: 3
+    positionSpring: 0
+    positionDamper: 0
+    maximumForce: 3.4028233e+38
+  m_ProjectionMode: 1
+  m_ProjectionDistance: 0.1
+  m_ProjectionAngle: 1
+  m_ConfiguredInWorldSpace: 0
+  m_SwapBodies: 0
+  m_BreakForce: Infinity
+  m_BreakTorque: Infinity
+  m_EnableCollision: 0
+  m_EnablePreprocessing: 1
+  m_MassScale: 1
+  m_ConnectedMassScale: 1
+--- !u!95 &1923249343152493210
+Animator:
+  serializedVersion: 5
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8805144180592550130}
+  m_Enabled: 1
+  m_Avatar: {fileID: 0}
+  m_Controller: {fileID: 9100000, guid: fdf61b3fa4a191d458611055dd90891e, type: 2}
+  m_CullingMode: 0
+  m_UpdateMode: 0
+  m_ApplyRootMotion: 0
+  m_LinearVelocityBlending: 0
+  m_StabilizeFeet: 0
+  m_WarningMessage: 
+  m_HasTransformHierarchy: 1
+  m_AllowConstantClipSamplingOptimization: 1
+  m_KeepAnimatorStateOnDisable: 0
+  m_WriteDefaultValuesOnDisable: 0
+--- !u!114 &6948572974031649383
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8805144180592550130}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 640d9fe099460244387c64255c73231d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  actions: {fileID: 11400000, guid: 4d02f5c2264e91947b3d186e35a17e0e, type: 2}
+  initAction: 501
+  animator: {fileID: 1923249343152493210}
+  stretchModule: {fileID: 0}
+  contactDistance: 1
+  currentAction:
+    Key: 0
+    Clip: 
+    ColliderX: 0
+    ColliderY: 0
+    TransitionDuration: 0
+    GravityScale: 0
+    MaxVelocityX: 0
+    MaxVelocityY: 0
+    NextAction: 0
+    FrameUpdates: 
+--- !u!114 &7202198038786721679
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8805144180592550130}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 55f2816284ccf4945be2fc16876a6d9e, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  pcActionKey: 109
+  clawActionKey: 502
+  isGrabbing: 0
+--- !u!114 &7761280840417631966
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8805144180592550130}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 253b17ea56337514899c81d174c925e6, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  g_scale: 0
+  deceleration: 1
+  maxSpeedX: 10
+  maxSpeedY: 10
+  jumpAllowed: 0
+  IsNoTurn: 0
+  speedXCoef: 0.5
+  speedYCoef: 0.5
+  speedX: 0
+  speedY: 0
+--- !u!1 &9056809845986802731 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 9087920638088774369, guid: 8ea9ec22169184ecca648dffc6de559b,
+    type: 3}
+  m_PrefabInstance: {fileID: 265298112320683722}
+  m_PrefabAsset: {fileID: 0}
+--- !u!54 &8256893280453544651
+Rigidbody:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 9056809845986802731}
+  serializedVersion: 2
+  m_Mass: 1
+  m_Drag: 0
+  m_AngularDrag: 0.05
+  m_UseGravity: 1
+  m_IsKinematic: 0
+  m_Interpolate: 0
+  m_Constraints: 0
+  m_CollisionDetection: 0
+--- !u!153 &7279340844363368887
+ConfigurableJoint:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 9056809845986802731}
+  m_ConnectedBody: {fileID: 7644639941302734877}
+  m_ConnectedArticulationBody: {fileID: 0}
+  m_Anchor: {x: 0, y: 0.5, z: 0}
+  m_Axis: {x: 0, y: 1, z: 0}
+  m_AutoConfigureConnectedAnchor: 1
+  m_ConnectedAnchor: {x: 0, y: 0, z: 0}
+  serializedVersion: 2
+  m_SecondaryAxis: {x: 0, y: 0, z: 1}
+  m_XMotion: 0
+  m_YMotion: 0
+  m_ZMotion: 0
+  m_AngularXMotion: 1
+  m_AngularYMotion: 1
+  m_AngularZMotion: 1
+  m_LinearLimitSpring:
+    spring: 0
+    damper: 0
+  m_LinearLimit:
+    limit: 0
+    bounciness: 0
+    contactDistance: 0
+  m_AngularXLimitSpring:
+    spring: 0
+    damper: 0
+  m_LowAngularXLimit:
+    limit: -30
+    bounciness: 0
+    contactDistance: 0
+  m_HighAngularXLimit:
+    limit: 1
+    bounciness: 0
+    contactDistance: 0
+  m_AngularYZLimitSpring:
+    spring: 0
+    damper: 0
+  m_AngularYLimit:
+    limit: 30
+    bounciness: 0
+    contactDistance: 0
+  m_AngularZLimit:
+    limit: 3
+    bounciness: 0
+    contactDistance: 0
+  m_TargetPosition: {x: 0, y: 0, z: 0}
+  m_TargetVelocity: {x: 0, y: 0, z: 0}
+  m_XDrive:
+    serializedVersion: 3
+    positionSpring: 0
+    positionDamper: 0
+    maximumForce: 3.4028233e+38
+  m_YDrive:
+    serializedVersion: 3
+    positionSpring: 0
+    positionDamper: 0
+    maximumForce: 3.4028233e+38
+  m_ZDrive:
+    serializedVersion: 3
+    positionSpring: 0
+    positionDamper: 0
+    maximumForce: 3.4028233e+38
+  m_TargetRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_TargetAngularVelocity: {x: 0, y: 0, z: 0}
+  m_RotationDriveMode: 0
+  m_AngularXDrive:
+    serializedVersion: 3
+    positionSpring: 500
+    positionDamper: 50
+    maximumForce: 3.4028233e+38
+  m_AngularYZDrive:
+    serializedVersion: 3
+    positionSpring: 0
+    positionDamper: 0
+    maximumForce: 3.4028233e+38
+  m_SlerpDrive:
+    serializedVersion: 3
+    positionSpring: 0
+    positionDamper: 0
+    maximumForce: 3.4028233e+38
+  m_ProjectionMode: 1
+  m_ProjectionDistance: 0.1
+  m_ProjectionAngle: 1
+  m_ConfiguredInWorldSpace: 0
+  m_SwapBodies: 0
+  m_BreakForce: Infinity
+  m_BreakTorque: Infinity
+  m_EnableCollision: 0
+  m_EnablePreprocessing: 1
+  m_MassScale: 1
+  m_ConnectedMassScale: 1

--- a/RunInBoots/Assets/Resources/TitleObject/ClawObject.prefab.meta
+++ b/RunInBoots/Assets/Resources/TitleObject/ClawObject.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: a7f7b53f29c0a3a4da75f4b06f776cc3
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/RunInBoots/Assets/Resources/TitleObject/CloudObject.prefab
+++ b/RunInBoots/Assets/Resources/TitleObject/CloudObject.prefab
@@ -1,0 +1,565 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &3291737719317621383
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 693443945601202063}
+  m_Layer: 3
+  m_Name: CloudObject
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &693443945601202063
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3291737719317621383}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 1008, y: 720, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 632353046288435436}
+  - {fileID: 9123266205241030614}
+  - {fileID: 6729579825275021865}
+  - {fileID: 779624989305320692}
+  - {fileID: 5015302785551011844}
+  - {fileID: 179154098247447720}
+  - {fileID: 2546083408276032819}
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1001 &429744985095885635
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 693443945601202063}
+    m_Modifications:
+    - target: {fileID: -8679921383154817045, guid: d45dfcb468db949ea80c7d228257781b,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 5
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: d45dfcb468db949ea80c7d228257781b,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: d45dfcb468db949ea80c7d228257781b,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: d45dfcb468db949ea80c7d228257781b,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: d45dfcb468db949ea80c7d228257781b,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: d45dfcb468db949ea80c7d228257781b,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: d45dfcb468db949ea80c7d228257781b,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: d45dfcb468db949ea80c7d228257781b,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: d45dfcb468db949ea80c7d228257781b,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: d45dfcb468db949ea80c7d228257781b,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: d45dfcb468db949ea80c7d228257781b,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 919132149155446097, guid: d45dfcb468db949ea80c7d228257781b,
+        type: 3}
+      propertyPath: m_Name
+      value: Mountain_Move_B (4)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: d45dfcb468db949ea80c7d228257781b, type: 3}
+--- !u!4 &179154098247447720 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: -8679921383154817045, guid: d45dfcb468db949ea80c7d228257781b,
+    type: 3}
+  m_PrefabInstance: {fileID: 429744985095885635}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &962487952262484767
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 693443945601202063}
+    m_Modifications:
+    - target: {fileID: -8679921383154817045, guid: d45dfcb468db949ea80c7d228257781b,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: d45dfcb468db949ea80c7d228257781b,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: d45dfcb468db949ea80c7d228257781b,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: d45dfcb468db949ea80c7d228257781b,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: d45dfcb468db949ea80c7d228257781b,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: d45dfcb468db949ea80c7d228257781b,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: d45dfcb468db949ea80c7d228257781b,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: d45dfcb468db949ea80c7d228257781b,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: d45dfcb468db949ea80c7d228257781b,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: d45dfcb468db949ea80c7d228257781b,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: d45dfcb468db949ea80c7d228257781b,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 919132149155446097, guid: d45dfcb468db949ea80c7d228257781b,
+        type: 3}
+      propertyPath: m_Name
+      value: Mountain_Move_B (2)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: d45dfcb468db949ea80c7d228257781b, type: 3}
+--- !u!4 &779624989305320692 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: -8679921383154817045, guid: d45dfcb468db949ea80c7d228257781b,
+    type: 3}
+  m_PrefabInstance: {fileID: 962487952262484767}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1102300829837553415
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 693443945601202063}
+    m_Modifications:
+    - target: {fileID: -8679921383154817045, guid: 78052aa7ad93e44dc8f448f3c74a57b2,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 78052aa7ad93e44dc8f448f3c74a57b2,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 78052aa7ad93e44dc8f448f3c74a57b2,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 78052aa7ad93e44dc8f448f3c74a57b2,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 78052aa7ad93e44dc8f448f3c74a57b2,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 78052aa7ad93e44dc8f448f3c74a57b2,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 78052aa7ad93e44dc8f448f3c74a57b2,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 78052aa7ad93e44dc8f448f3c74a57b2,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 78052aa7ad93e44dc8f448f3c74a57b2,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 78052aa7ad93e44dc8f448f3c74a57b2,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 78052aa7ad93e44dc8f448f3c74a57b2,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 919132149155446097, guid: 78052aa7ad93e44dc8f448f3c74a57b2,
+        type: 3}
+      propertyPath: m_Name
+      value: Mountain_Move_A
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 78052aa7ad93e44dc8f448f3c74a57b2, type: 3}
+--- !u!4 &632353046288435436 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: -8679921383154817045, guid: 78052aa7ad93e44dc8f448f3c74a57b2,
+    type: 3}
+  m_PrefabInstance: {fileID: 1102300829837553415}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &2656904031375616728
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 693443945601202063}
+    m_Modifications:
+    - target: {fileID: -8679921383154817045, guid: ae0ba1eabe31c4b1d879c7a19c7f7f8d,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: ae0ba1eabe31c4b1d879c7a19c7f7f8d,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -2
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: ae0ba1eabe31c4b1d879c7a19c7f7f8d,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: ae0ba1eabe31c4b1d879c7a19c7f7f8d,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: ae0ba1eabe31c4b1d879c7a19c7f7f8d,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.0000000754979
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: ae0ba1eabe31c4b1d879c7a19c7f7f8d,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: ae0ba1eabe31c4b1d879c7a19c7f7f8d,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: ae0ba1eabe31c4b1d879c7a19c7f7f8d,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: ae0ba1eabe31c4b1d879c7a19c7f7f8d,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: ae0ba1eabe31c4b1d879c7a19c7f7f8d,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: ae0ba1eabe31c4b1d879c7a19c7f7f8d,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 919132149155446097, guid: ae0ba1eabe31c4b1d879c7a19c7f7f8d,
+        type: 3}
+      propertyPath: m_Name
+      value: Mountain_Move_C
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: ae0ba1eabe31c4b1d879c7a19c7f7f8d, type: 3}
+--- !u!4 &2546083408276032819 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: -8679921383154817045, guid: ae0ba1eabe31c4b1d879c7a19c7f7f8d,
+    type: 3}
+  m_PrefabInstance: {fileID: 2656904031375616728}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &4761244007356889071
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 693443945601202063}
+    m_Modifications:
+    - target: {fileID: -8679921383154817045, guid: d45dfcb468db949ea80c7d228257781b,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 4
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: d45dfcb468db949ea80c7d228257781b,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: d45dfcb468db949ea80c7d228257781b,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: d45dfcb468db949ea80c7d228257781b,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: d45dfcb468db949ea80c7d228257781b,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: d45dfcb468db949ea80c7d228257781b,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: d45dfcb468db949ea80c7d228257781b,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: d45dfcb468db949ea80c7d228257781b,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: d45dfcb468db949ea80c7d228257781b,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: d45dfcb468db949ea80c7d228257781b,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: d45dfcb468db949ea80c7d228257781b,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 919132149155446097, guid: d45dfcb468db949ea80c7d228257781b,
+        type: 3}
+      propertyPath: m_Name
+      value: Mountain_Move_B (3)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: d45dfcb468db949ea80c7d228257781b, type: 3}
+--- !u!4 &5015302785551011844 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: -8679921383154817045, guid: d45dfcb468db949ea80c7d228257781b,
+    type: 3}
+  m_PrefabInstance: {fileID: 4761244007356889071}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &6552451925237452226
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 693443945601202063}
+    m_Modifications:
+    - target: {fileID: -8679921383154817045, guid: d45dfcb468db949ea80c7d228257781b,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: d45dfcb468db949ea80c7d228257781b,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: d45dfcb468db949ea80c7d228257781b,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: d45dfcb468db949ea80c7d228257781b,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: d45dfcb468db949ea80c7d228257781b,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: d45dfcb468db949ea80c7d228257781b,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: d45dfcb468db949ea80c7d228257781b,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: d45dfcb468db949ea80c7d228257781b,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: d45dfcb468db949ea80c7d228257781b,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: d45dfcb468db949ea80c7d228257781b,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: d45dfcb468db949ea80c7d228257781b,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 919132149155446097, guid: d45dfcb468db949ea80c7d228257781b,
+        type: 3}
+      propertyPath: m_Name
+      value: Mountain_Move_B (1)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: d45dfcb468db949ea80c7d228257781b, type: 3}
+--- !u!4 &6729579825275021865 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: -8679921383154817045, guid: d45dfcb468db949ea80c7d228257781b,
+    type: 3}
+  m_PrefabInstance: {fileID: 6552451925237452226}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &8725411173640097853
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 693443945601202063}
+    m_Modifications:
+    - target: {fileID: -8679921383154817045, guid: d45dfcb468db949ea80c7d228257781b,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: d45dfcb468db949ea80c7d228257781b,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -2
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: d45dfcb468db949ea80c7d228257781b,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: d45dfcb468db949ea80c7d228257781b,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: d45dfcb468db949ea80c7d228257781b,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: d45dfcb468db949ea80c7d228257781b,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: d45dfcb468db949ea80c7d228257781b,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: d45dfcb468db949ea80c7d228257781b,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: d45dfcb468db949ea80c7d228257781b,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: d45dfcb468db949ea80c7d228257781b,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: d45dfcb468db949ea80c7d228257781b,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 919132149155446097, guid: d45dfcb468db949ea80c7d228257781b,
+        type: 3}
+      propertyPath: m_Name
+      value: Mountain_Move_B
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: d45dfcb468db949ea80c7d228257781b, type: 3}
+--- !u!4 &9123266205241030614 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: -8679921383154817045, guid: d45dfcb468db949ea80c7d228257781b,
+    type: 3}
+  m_PrefabInstance: {fileID: 8725411173640097853}
+  m_PrefabAsset: {fileID: 0}

--- a/RunInBoots/Assets/Resources/TitleObject/CloudObject.prefab.meta
+++ b/RunInBoots/Assets/Resources/TitleObject/CloudObject.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 65cd3a37c4f23de4698298e9edfa996a
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/RunInBoots/Assets/Resources/TitleObject/DogObject.prefab
+++ b/RunInBoots/Assets/Resources/TitleObject/DogObject.prefab
@@ -1,0 +1,151 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &1228525238977188820
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1228525238977188816}
+  m_Layer: 7
+  m_Name: DogObject
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1228525238977188816
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1228525238977188820}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 1840773375703557454}
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1001 &2162014641678697125
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 1228525238977188816}
+    m_Modifications:
+    - target: {fileID: -8679921383154817045, guid: dbb5cef31b7d24b7aa70eabda32e49ec,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: dbb5cef31b7d24b7aa70eabda32e49ec,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: dbb5cef31b7d24b7aa70eabda32e49ec,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: dbb5cef31b7d24b7aa70eabda32e49ec,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: dbb5cef31b7d24b7aa70eabda32e49ec,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: dbb5cef31b7d24b7aa70eabda32e49ec,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: dbb5cef31b7d24b7aa70eabda32e49ec,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: dbb5cef31b7d24b7aa70eabda32e49ec,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: dbb5cef31b7d24b7aa70eabda32e49ec,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: dbb5cef31b7d24b7aa70eabda32e49ec,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: dbb5cef31b7d24b7aa70eabda32e49ec,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: dbb5cef31b7d24b7aa70eabda32e49ec,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: dbb5cef31b7d24b7aa70eabda32e49ec,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 90
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: dbb5cef31b7d24b7aa70eabda32e49ec,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 919132149155446097, guid: dbb5cef31b7d24b7aa70eabda32e49ec,
+        type: 3}
+      propertyPath: m_Name
+      value: Dog
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: dbb5cef31b7d24b7aa70eabda32e49ec, type: 3}
+--- !u!1 &1351199792834740212 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 919132149155446097, guid: dbb5cef31b7d24b7aa70eabda32e49ec,
+    type: 3}
+  m_PrefabInstance: {fileID: 2162014641678697125}
+  m_PrefabAsset: {fileID: 0}
+--- !u!95 &5441874078137359109
+Animator:
+  serializedVersion: 5
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1351199792834740212}
+  m_Enabled: 1
+  m_Avatar: {fileID: 0}
+  m_Controller: {fileID: 9100000, guid: 117ce63293f9f7b4cad320515f457efe, type: 2}
+  m_CullingMode: 0
+  m_UpdateMode: 0
+  m_ApplyRootMotion: 0
+  m_LinearVelocityBlending: 0
+  m_StabilizeFeet: 0
+  m_WarningMessage: 
+  m_HasTransformHierarchy: 1
+  m_AllowConstantClipSamplingOptimization: 1
+  m_KeepAnimatorStateOnDisable: 0
+  m_WriteDefaultValuesOnDisable: 0
+--- !u!4 &1840773375703557454 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: -8679921383154817045, guid: dbb5cef31b7d24b7aa70eabda32e49ec,
+    type: 3}
+  m_PrefabInstance: {fileID: 2162014641678697125}
+  m_PrefabAsset: {fileID: 0}

--- a/RunInBoots/Assets/Resources/TitleObject/DogObject.prefab.meta
+++ b/RunInBoots/Assets/Resources/TitleObject/DogObject.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: e9b384e89dcc44f49a591884262b7eba
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/RunInBoots/Assets/Resources/TitleObject/MouseObject.prefab
+++ b/RunInBoots/Assets/Resources/TitleObject/MouseObject.prefab
@@ -1,0 +1,3591 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &347463329224910665
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1000062606691290481}
+  m_Layer: 0
+  m_Name: lid.T.R.001
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1000062606691290481
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 347463329224910665}
+  m_LocalRotation: {x: -0.2588799, y: 0.24442236, z: -0.05964199, w: 0.9325673}
+  m_LocalPosition: {x: 1.8626451e-11, y: 0.0005004261, z: -6.1467287e-10}
+  m_LocalScale: {x: 0.99999994, y: 1, z: 1.0000001}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 7646319325853042592}
+  m_Father: {fileID: 3791009844188970446}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &386583455891520466
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 335622516012745582}
+  - component: {fileID: 1834383372240310363}
+  m_Layer: 0
+  m_Name: MouseObject
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &335622516012745582
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 386583455891520466}
+  m_LocalRotation: {x: 0, y: 1, z: 0, w: 0}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 5616293758670104310}
+  - {fileID: 7923647521316177041}
+  - {fileID: 19616790093322360}
+  - {fileID: 1831121597379004836}
+  - {fileID: 1928065744544838147}
+  - {fileID: 5798145390520151183}
+  - {fileID: 2973821386496620014}
+  - {fileID: 5817924570505893681}
+  - {fileID: 50334520836951344}
+  - {fileID: 8065942682849665467}
+  - {fileID: 4079263573560234762}
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 180, z: 0}
+--- !u!95 &1834383372240310363
+Animator:
+  serializedVersion: 5
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 386583455891520466}
+  m_Enabled: 1
+  m_Avatar: {fileID: 0}
+  m_Controller: {fileID: 9100000, guid: 7b65838049d154caf8db76a3eddb17bf, type: 2}
+  m_CullingMode: 0
+  m_UpdateMode: 0
+  m_ApplyRootMotion: 0
+  m_LinearVelocityBlending: 0
+  m_StabilizeFeet: 0
+  m_WarningMessage: 
+  m_HasTransformHierarchy: 1
+  m_AllowConstantClipSamplingOptimization: 1
+  m_KeepAnimatorStateOnDisable: 0
+  m_WriteDefaultValuesOnDisable: 0
+--- !u!1 &418301122191271026
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1611184371004493056}
+  m_Layer: 0
+  m_Name: lid.T.R.003
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1611184371004493056
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 418301122191271026}
+  m_LocalRotation: {x: -0.3445355, y: 0.34160635, z: -0.26835304, w: 0.83221817}
+  m_LocalPosition: {x: 2.8871e-10, y: 0.0005270014, z: -1.6763806e-10}
+  m_LocalScale: {x: 1, y: 1.0000001, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 2003040163381912285}
+  m_Father: {fileID: 7646319325853042592}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &418864512939479016
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3211587423538233371}
+  m_Layer: 0
+  m_Name: lid.B.L.002
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &3211587423538233371
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 418864512939479016}
+  m_LocalRotation: {x: 0.29188064, y: -0.113145545, z: -0.2041172, w: 0.92754513}
+  m_LocalPosition: {x: -2.7939677e-11, y: 0.0006454672, z: -5.075708e-10}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 5100113213617578379}
+  m_Father: {fileID: 7632820076041517190}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &449885551744605332
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7923647521316177041}
+  - component: {fileID: 3468388091685455042}
+  m_Layer: 0
+  m_Name: Eye.L
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &7923647521316177041
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 449885551744605332}
+  m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: -0.09676143, y: 0.29236382, z: 0.06942275}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 335622516012745582}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!137 &3468388091685455042
+SkinnedMeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 449885551744605332}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 3
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 5292afcaf552f4340a3f2b0cf314e22e, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  serializedVersion: 2
+  m_Quality: 0
+  m_UpdateWhenOffscreen: 0
+  m_SkinnedMotionVectors: 1
+  m_Mesh: {fileID: -85030299752697963, guid: 1eab608e50838480cb5624ef972aaefa, type: 3}
+  m_Bones:
+  - {fileID: 634489825855426036}
+  - {fileID: 5207653694212286752}
+  - {fileID: 5333863218529137871}
+  - {fileID: 20865142993964904}
+  - {fileID: 3434650260761326427}
+  - {fileID: 3871633738844993740}
+  - {fileID: 6564332047592217517}
+  - {fileID: 7538186458141369528}
+  - {fileID: 975176030087924512}
+  - {fileID: 3695128100402780833}
+  - {fileID: 5636246135290840368}
+  - {fileID: 1379374467916002387}
+  - {fileID: 8020341672044078963}
+  - {fileID: 4811824318893303174}
+  - {fileID: 5076154694908286685}
+  - {fileID: 2317744451904098287}
+  - {fileID: 5922780046748858856}
+  - {fileID: 4588486639810444708}
+  - {fileID: 7632820076041517190}
+  - {fileID: 3211587423538233371}
+  - {fileID: 5100113213617578379}
+  - {fileID: 3791009844188970446}
+  - {fileID: 1000062606691290481}
+  - {fileID: 7646319325853042592}
+  - {fileID: 1611184371004493056}
+  - {fileID: 2003040163381912285}
+  - {fileID: 491528560663723884}
+  - {fileID: 4637473732372620200}
+  - {fileID: 2031732954974184158}
+  - {fileID: 7025723684427687055}
+  - {fileID: 6160296006110967135}
+  - {fileID: 7855641395134033136}
+  - {fileID: 4716361704291802426}
+  - {fileID: 7898737408510310671}
+  - {fileID: 5459686724456291437}
+  - {fileID: 6294312701372281717}
+  - {fileID: 4989387358061816488}
+  - {fileID: 2129881336522630087}
+  - {fileID: 3838292567987109152}
+  - {fileID: 3273720198767295813}
+  - {fileID: 5428258405080415649}
+  - {fileID: 8233220451044933438}
+  - {fileID: 5159362533255290944}
+  - {fileID: 9146235272556288709}
+  - {fileID: 7962682501229320312}
+  - {fileID: 6637270760791400288}
+  - {fileID: 995635320910262429}
+  - {fileID: 2814128027687768141}
+  - {fileID: 2475552407399262431}
+  - {fileID: 6377510050095406218}
+  m_BlendShapeWeights: []
+  m_RootBone: {fileID: 634489825855426036}
+  m_AABB:
+    m_Center: {x: -0.0009609447, y: 0.007264587, z: 0.0010245442}
+    m_Extent: {x: 0.0009616185, y: 0.0009623759, z: 0.00066844095}
+  m_DirtyAABB: 0
+--- !u!1 &456539773471944010
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5798145390520151183}
+  m_Layer: 0
+  m_Name: Rat Rig
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &5798145390520151183
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 456539773471944010}
+  m_LocalRotation: {x: -0.7069834, y: 0, z: 0, w: 0.7072302}
+  m_LocalPosition: {x: -0, y: -0.4876622, z: 0}
+  m_LocalScale: {x: 100, y: 100, z: 100}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 634489825855426036}
+  m_Father: {fileID: 335622516012745582}
+  m_RootOrder: 5
+  m_LocalEulerAnglesHint: {x: -89.98, y: 0, z: 0}
+--- !u!1 &515337530120495348
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8020341672044078963}
+  m_Layer: 0
+  m_Name: lip.B.R.001
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &8020341672044078963
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 515337530120495348}
+  m_LocalRotation: {x: 0.31550404, y: 0.2140016, z: -0.10408499, w: 0.9186005}
+  m_LocalPosition: {x: 9.313225e-11, y: 0.00096883613, z: 3.7252902e-11}
+  m_LocalScale: {x: 1, y: 1.0000001, z: 0.99999994}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 8653288001088028898}
+  m_Father: {fileID: 1379374467916002387}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &594569818352785632
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1831121597379004836}
+  - component: {fileID: 3954107222704056963}
+  m_Layer: 0
+  m_Name: Head
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1831121597379004836
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 594569818352785632}
+  m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: -0, y: 0.25125366, z: -0.022185344}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 335622516012745582}
+  m_RootOrder: 3
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!137 &3954107222704056963
+SkinnedMeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 594569818352785632}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 3
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: e38aaca5098d04717af2082571330b28, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  serializedVersion: 2
+  m_Quality: 0
+  m_UpdateWhenOffscreen: 0
+  m_SkinnedMotionVectors: 1
+  m_Mesh: {fileID: -8839368762345780380, guid: 1eab608e50838480cb5624ef972aaefa, type: 3}
+  m_Bones:
+  - {fileID: 634489825855426036}
+  - {fileID: 5207653694212286752}
+  - {fileID: 5333863218529137871}
+  - {fileID: 20865142993964904}
+  - {fileID: 3434650260761326427}
+  - {fileID: 3871633738844993740}
+  - {fileID: 6564332047592217517}
+  - {fileID: 7538186458141369528}
+  - {fileID: 975176030087924512}
+  - {fileID: 3695128100402780833}
+  - {fileID: 5636246135290840368}
+  - {fileID: 1379374467916002387}
+  - {fileID: 8020341672044078963}
+  - {fileID: 4811824318893303174}
+  - {fileID: 5076154694908286685}
+  - {fileID: 2317744451904098287}
+  - {fileID: 5922780046748858856}
+  - {fileID: 4588486639810444708}
+  - {fileID: 7632820076041517190}
+  - {fileID: 3211587423538233371}
+  - {fileID: 5100113213617578379}
+  - {fileID: 3791009844188970446}
+  - {fileID: 1000062606691290481}
+  - {fileID: 7646319325853042592}
+  - {fileID: 1611184371004493056}
+  - {fileID: 2003040163381912285}
+  - {fileID: 491528560663723884}
+  - {fileID: 4637473732372620200}
+  - {fileID: 2031732954974184158}
+  - {fileID: 7025723684427687055}
+  - {fileID: 6160296006110967135}
+  - {fileID: 7855641395134033136}
+  - {fileID: 4716361704291802426}
+  - {fileID: 7898737408510310671}
+  - {fileID: 5459686724456291437}
+  - {fileID: 6294312701372281717}
+  - {fileID: 4989387358061816488}
+  - {fileID: 2129881336522630087}
+  - {fileID: 3838292567987109152}
+  - {fileID: 3273720198767295813}
+  - {fileID: 5428258405080415649}
+  - {fileID: 8233220451044933438}
+  - {fileID: 5159362533255290944}
+  - {fileID: 9146235272556288709}
+  - {fileID: 7962682501229320312}
+  - {fileID: 6637270760791400288}
+  - {fileID: 995635320910262429}
+  - {fileID: 2814128027687768141}
+  - {fileID: 2475552407399262431}
+  - {fileID: 6377510050095406218}
+  m_BlendShapeWeights: []
+  m_RootBone: {fileID: 634489825855426036}
+  m_AABB:
+    m_Center: {x: 2.3283064e-10, y: 0.006845372, z: -0.00048700674}
+    m_Extent: {x: 0.005149317, y: 0.0031733883, z: 0.003198658}
+  m_DirtyAABB: 0
+--- !u!1 &672934337211916000
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3169483791844907622}
+  m_Layer: 0
+  m_Name: tail.002_end
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &3169483791844907622
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 672934337211916000}
+  m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: -0, y: 0.0014642319, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 6377510050095406218}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &806687204649727431
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4989387358061816488}
+  m_Layer: 0
+  m_Name: shoulder.R
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &4989387358061816488
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 806687204649727431}
+  m_LocalRotation: {x: -0.5872977, y: -0.42551482, z: -0.39496922, w: 0.56393075}
+  m_LocalPosition: {x: 0.0002243488, y: 0.0015015386, z: 0.00018788909}
+  m_LocalScale: {x: 0.99999994, y: 0.9999998, z: 0.99999994}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 2129881336522630087}
+  m_Father: {fileID: 5333863218529137871}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &847632116989076425
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1379374467916002387}
+  m_Layer: 0
+  m_Name: lip.B.R
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1379374467916002387
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 847632116989076425}
+  m_LocalRotation: {x: -0.31234026, y: -0.5530192, z: -0.46602732, w: 0.6159804}
+  m_LocalPosition: {x: 2.457482e-10, y: -0.000016328106, z: 0.0010140681}
+  m_LocalScale: {x: 1, y: 1, z: 0.99999994}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 8020341672044078963}
+  m_Father: {fileID: 3434650260761326427}
+  m_RootOrder: 7
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &955651451621139934
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4588486639810444708}
+  m_Layer: 0
+  m_Name: lid.B.L
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &4588486639810444708
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 955651451621139934}
+  m_LocalRotation: {x: -0.037349086, y: 0.87058747, z: -0.30158472, w: -0.38694853}
+  m_LocalPosition: {x: 2.4214386e-10, y: 0.0005589862, z: 0}
+  m_LocalScale: {x: 1, y: 1.0000004, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 7632820076041517190}
+  m_Father: {fileID: 5922780046748858856}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &964481818841961730
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6105822404964798573}
+  m_Layer: 0
+  m_Name: ear.R_end
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &6105822404964798573
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 964481818841961730}
+  m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: -0, y: 0.0009499521, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 4716361704291802426}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1040113013681666860
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4079263573560234762}
+  - component: {fileID: 8278684899442905936}
+  m_Layer: 0
+  m_Name: Tooth.004
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &4079263573560234762
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1040113013681666860}
+  m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0.04905063, y: 0.1459652, z: 0.13672218}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 335622516012745582}
+  m_RootOrder: 10
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!137 &8278684899442905936
+SkinnedMeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1040113013681666860}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 3
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 31321ba15b8f8eb4c954353edc038b1d, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  serializedVersion: 2
+  m_Quality: 0
+  m_UpdateWhenOffscreen: 0
+  m_SkinnedMotionVectors: 1
+  m_Mesh: {fileID: 3749252552994711399, guid: 1eab608e50838480cb5624ef972aaefa, type: 3}
+  m_Bones:
+  - {fileID: 634489825855426036}
+  - {fileID: 5207653694212286752}
+  - {fileID: 5333863218529137871}
+  - {fileID: 20865142993964904}
+  - {fileID: 3434650260761326427}
+  - {fileID: 3871633738844993740}
+  - {fileID: 6564332047592217517}
+  - {fileID: 7538186458141369528}
+  - {fileID: 975176030087924512}
+  - {fileID: 3695128100402780833}
+  - {fileID: 5636246135290840368}
+  - {fileID: 1379374467916002387}
+  - {fileID: 8020341672044078963}
+  - {fileID: 4811824318893303174}
+  - {fileID: 5076154694908286685}
+  - {fileID: 2317744451904098287}
+  - {fileID: 5922780046748858856}
+  - {fileID: 4588486639810444708}
+  - {fileID: 7632820076041517190}
+  - {fileID: 3211587423538233371}
+  - {fileID: 5100113213617578379}
+  - {fileID: 3791009844188970446}
+  - {fileID: 1000062606691290481}
+  - {fileID: 7646319325853042592}
+  - {fileID: 1611184371004493056}
+  - {fileID: 2003040163381912285}
+  - {fileID: 491528560663723884}
+  - {fileID: 4637473732372620200}
+  - {fileID: 2031732954974184158}
+  - {fileID: 7025723684427687055}
+  - {fileID: 6160296006110967135}
+  - {fileID: 7855641395134033136}
+  - {fileID: 4716361704291802426}
+  - {fileID: 7898737408510310671}
+  - {fileID: 5459686724456291437}
+  - {fileID: 6294312701372281717}
+  - {fileID: 4989387358061816488}
+  - {fileID: 2129881336522630087}
+  - {fileID: 3838292567987109152}
+  - {fileID: 3273720198767295813}
+  - {fileID: 5428258405080415649}
+  - {fileID: 8233220451044933438}
+  - {fileID: 5159362533255290944}
+  - {fileID: 9146235272556288709}
+  - {fileID: 7962682501229320312}
+  - {fileID: 6637270760791400288}
+  - {fileID: 995635320910262429}
+  - {fileID: 2814128027687768141}
+  - {fileID: 2475552407399262431}
+  - {fileID: 6377510050095406218}
+  m_BlendShapeWeights: []
+  m_RootBone: {fileID: 634489825855426036}
+  m_AABB:
+    m_Center: {x: 0.000506192, y: 0.0058165533, z: 0.0017743803}
+    m_Extent: {x: 0.00014699574, y: 0.00015857397, z: 0.000112706446}
+  m_DirtyAABB: 0
+--- !u!1 &1086717297974557781
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3791009844188970446}
+  m_Layer: 0
+  m_Name: lid.T.R
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &3791009844188970446
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1086717297974557781}
+  m_LocalRotation: {x: -0.090493605, y: 0.5692287, z: 0.31790063, w: 0.75281394}
+  m_LocalPosition: {x: 0.0017716486, y: 0.0025302153, z: 0.00091207435}
+  m_LocalScale: {x: 0.9999999, y: 0.99999994, z: 0.99999994}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 1000062606691290481}
+  m_Father: {fileID: 3434650260761326427}
+  m_RootOrder: 5
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1659063290341191031
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4716361704291802426}
+  m_Layer: 0
+  m_Name: ear.R
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &4716361704291802426
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1659063290341191031}
+  m_LocalRotation: {x: -0.32616866, y: -0.20642416, z: -0.54106116, w: 0.7471653}
+  m_LocalPosition: {x: 0.0022817971, y: 0.0025916488, z: -0.0006456094}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 6105822404964798573}
+  m_Father: {fileID: 3434650260761326427}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1790025357182243332
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4811824318893303174}
+  m_Layer: 0
+  m_Name: lid.T.L
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &4811824318893303174
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1790025357182243332}
+  m_LocalRotation: {x: -0.090493776, y: -0.5692285, z: -0.31790075, w: 0.75281405}
+  m_LocalPosition: {x: -0.0017716483, y: 0.0025302153, z: 0.0009120752}
+  m_LocalScale: {x: 0.9999999, y: 0.9999999, z: 0.99999994}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 5076154694908286685}
+  m_Father: {fileID: 3434650260761326427}
+  m_RootOrder: 4
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1915014187235982272
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 975176030087924512}
+  m_Layer: 0
+  m_Name: lip.B.L.001
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &975176030087924512
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1915014187235982272}
+  m_LocalRotation: {x: 0.31550404, y: -0.21400172, z: 0.104084946, w: 0.91860044}
+  m_LocalPosition: {x: 4.1909514e-11, y: 0.00096883596, z: -3.5390257e-10}
+  m_LocalScale: {x: 1.0000001, y: 1.0000001, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 870923334678167550}
+  m_Father: {fileID: 7538186458141369528}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1928624978725519740
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6377510050095406218}
+  m_Layer: 0
+  m_Name: tail.002
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &6377510050095406218
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1928624978725519740}
+  m_LocalRotation: {x: -0.14724237, y: -1.4954559e-15, z: 0.000000035105316, w: 0.98910046}
+  m_LocalPosition: {x: 3.6359802e-17, y: 0.0013758647, z: -1.11758706e-10}
+  m_LocalScale: {x: 1, y: 1.0000001, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 3169483791844907622}
+  m_Father: {fileID: 2475552407399262431}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &2008570605131439121
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2317744451904098287}
+  m_Layer: 0
+  m_Name: lid.T.L.002
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &2317744451904098287
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2008570605131439121}
+  m_LocalRotation: {x: -0.34537926, y: -0.09603819, z: -0.067310594, w: 0.9311064}
+  m_LocalPosition: {x: -1.2107193e-10, y: 0.0005315045, z: 4.842877e-10}
+  m_LocalScale: {x: 1, y: 0.99999994, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 5922780046748858856}
+  m_Father: {fileID: 5076154694908286685}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &2428477427577818431
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5946690229846915520}
+  m_Layer: 0
+  m_Name: forearm.L_end
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &5946690229846915520
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2428477427577818431}
+  m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: -0, y: 0.0011943749, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 6294312701372281717}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &2555562083575197025
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5459686724456291437}
+  m_Layer: 0
+  m_Name: upper_arm.L
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &5459686724456291437
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2555562083575197025}
+  m_LocalRotation: {x: 0.24501982, y: -0.7138058, z: -0.01148833, w: 0.6559837}
+  m_LocalPosition: {x: 2.7939677e-11, y: 0.0009955601, z: -1.4086253e-10}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 6294312701372281717}
+  m_Father: {fileID: 7898737408510310671}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &2684476863278288391
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7005886737581518621}
+  m_Layer: 0
+  m_Name: eye.R_end
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &7005886737581518621
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2684476863278288391}
+  m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: -0, y: 0.0003371168, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 6160296006110967135}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &2718626016733644114
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5636246135290840368}
+  m_Layer: 0
+  m_Name: lip.T.R.001
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &5636246135290840368
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2718626016733644114}
+  m_LocalRotation: {x: 0.008019859, y: -0.105553836, z: -0.11037016, w: 0.9882371}
+  m_LocalPosition: {x: 1.11758706e-10, y: 0.0005741662, z: 6.7520885e-11}
+  m_LocalScale: {x: 1, y: 1.0000001, z: 1.0000001}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 7621218117233582883}
+  m_Father: {fileID: 3695128100402780833}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &3023816460678437475
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 20865142993964904}
+  m_Layer: 0
+  m_Name: spine.005
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &20865142993964904
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3023816460678437475}
+  m_LocalRotation: {x: 0.037887774, y: -0.00000011912369, z: -0.000000004516576, w: 0.999282}
+  m_LocalPosition: {x: -1.5568227e-19, y: 0.0015209143, z: -0.0000013357214}
+  m_LocalScale: {x: 1, y: 0.99999994, z: 0.9999999}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 3434650260761326427}
+  m_Father: {fileID: 5333863218529137871}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &3043004599331869396
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8233220451044933438}
+  m_Layer: 0
+  m_Name: thigh.L
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &8233220451044933438
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3043004599331869396}
+  m_LocalRotation: {x: 0.76015097, y: -0.30202684, z: 0.028618578, w: 0.57457054}
+  m_LocalPosition: {x: -0.001227175, y: 0.0014785377, z: -0.000022244822}
+  m_LocalScale: {x: 0.99999994, y: 0.9999999, z: 0.99999994}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 5159362533255290944}
+  m_Father: {fileID: 634489825855426036}
+  m_RootOrder: 4
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &3185419774565357792
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5076154694908286685}
+  m_Layer: 0
+  m_Name: lid.T.L.001
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &5076154694908286685
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3185419774565357792}
+  m_LocalRotation: {x: -0.25887972, y: -0.24442244, z: 0.059641942, w: 0.93256736}
+  m_LocalPosition: {x: -2.4214386e-10, y: 0.00050042634, z: -5.7742e-10}
+  m_LocalScale: {x: 1, y: 0.99999994, z: 1.0000001}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 2317744451904098287}
+  m_Father: {fileID: 4811824318893303174}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &3357307110953188743
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7898737408510310671}
+  m_Layer: 0
+  m_Name: shoulder.L
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &7898737408510310671
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3357307110953188743}
+  m_LocalRotation: {x: -0.5872977, y: 0.42551482, z: 0.39496922, w: 0.56393075}
+  m_LocalPosition: {x: -0.0002243488, y: 0.0015015386, z: 0.00018788909}
+  m_LocalScale: {x: 0.99999994, y: 0.9999998, z: 0.99999994}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 5459686724456291437}
+  m_Father: {fileID: 5333863218529137871}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &3429361529197698543
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3838292567987109152}
+  m_Layer: 0
+  m_Name: forearm.R
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &3838292567987109152
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3429361529197698543}
+  m_LocalRotation: {x: 0.014086968, y: -0.66807765, z: 0.047943864, w: 0.74241173}
+  m_LocalPosition: {x: -1.6763806e-10, y: 0.001128123, z: -1.11758706e-10}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 1155640887668266983}
+  m_Father: {fileID: 2129881336522630087}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &3504274944132191216
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5159362533255290944}
+  m_Layer: 0
+  m_Name: shin.L
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &5159362533255290944
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3504274944132191216}
+  m_LocalRotation: {x: 0.5540742, y: 0.018545685, z: -0.3247109, w: 0.76630324}
+  m_LocalPosition: {x: -7.4505804e-11, y: 0.00059022696, z: -8.8475643e-11}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 9146235272556288709}
+  m_Father: {fileID: 8233220451044933438}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &3603031057780484382
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6259286334483318099}
+  m_Layer: 0
+  m_Name: eye.L_end
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &6259286334483318099
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3603031057780484382}
+  m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: -0, y: 0.0003371168, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 7025723684427687055}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &3620288070707216785
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5207653694212286752}
+  m_Layer: 0
+  m_Name: spine.001
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &5207653694212286752
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3620288070707216785}
+  m_LocalRotation: {x: 0.007276122, y: 3.803101e-15, z: -0.0000000017347628, w: 0.99997354}
+  m_LocalPosition: {x: -1.4432899e-17, y: 0.0016386727, z: 4.1633362e-19}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 5333863218529137871}
+  m_Father: {fileID: 634489825855426036}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &3648148042662595858
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5394006323550395795}
+  m_Layer: 0
+  m_Name: foot.L_end
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &5394006323550395795
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3648148042662595858}
+  m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: -0, y: 0.0010071099, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 9146235272556288709}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &3792746997725880818
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8065942682849665467}
+  - component: {fileID: 6181608610195547627}
+  m_Layer: 0
+  m_Name: Tooth.003
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &8065942682849665467
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3792746997725880818}
+  m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0.0154990535, y: 0.14621697, z: 0.13672218}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 335622516012745582}
+  m_RootOrder: 9
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!137 &6181608610195547627
+SkinnedMeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3792746997725880818}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 3
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 31321ba15b8f8eb4c954353edc038b1d, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  serializedVersion: 2
+  m_Quality: 0
+  m_UpdateWhenOffscreen: 0
+  m_SkinnedMotionVectors: 1
+  m_Mesh: {fileID: -3404266066268447749, guid: 1eab608e50838480cb5624ef972aaefa, type: 3}
+  m_Bones:
+  - {fileID: 634489825855426036}
+  - {fileID: 5207653694212286752}
+  - {fileID: 5333863218529137871}
+  - {fileID: 20865142993964904}
+  - {fileID: 3434650260761326427}
+  - {fileID: 3871633738844993740}
+  - {fileID: 6564332047592217517}
+  - {fileID: 7538186458141369528}
+  - {fileID: 975176030087924512}
+  - {fileID: 3695128100402780833}
+  - {fileID: 5636246135290840368}
+  - {fileID: 1379374467916002387}
+  - {fileID: 8020341672044078963}
+  - {fileID: 4811824318893303174}
+  - {fileID: 5076154694908286685}
+  - {fileID: 2317744451904098287}
+  - {fileID: 5922780046748858856}
+  - {fileID: 4588486639810444708}
+  - {fileID: 7632820076041517190}
+  - {fileID: 3211587423538233371}
+  - {fileID: 5100113213617578379}
+  - {fileID: 3791009844188970446}
+  - {fileID: 1000062606691290481}
+  - {fileID: 7646319325853042592}
+  - {fileID: 1611184371004493056}
+  - {fileID: 2003040163381912285}
+  - {fileID: 491528560663723884}
+  - {fileID: 4637473732372620200}
+  - {fileID: 2031732954974184158}
+  - {fileID: 7025723684427687055}
+  - {fileID: 6160296006110967135}
+  - {fileID: 7855641395134033136}
+  - {fileID: 4716361704291802426}
+  - {fileID: 7898737408510310671}
+  - {fileID: 5459686724456291437}
+  - {fileID: 6294312701372281717}
+  - {fileID: 4989387358061816488}
+  - {fileID: 2129881336522630087}
+  - {fileID: 3838292567987109152}
+  - {fileID: 3273720198767295813}
+  - {fileID: 5428258405080415649}
+  - {fileID: 8233220451044933438}
+  - {fileID: 5159362533255290944}
+  - {fileID: 9146235272556288709}
+  - {fileID: 7962682501229320312}
+  - {fileID: 6637270760791400288}
+  - {fileID: 995635320910262429}
+  - {fileID: 2814128027687768141}
+  - {fileID: 2475552407399262431}
+  - {fileID: 6377510050095406218}
+  m_BlendShapeWeights: []
+  m_RootBone: {fileID: 634489825855426036}
+  m_AABB:
+    m_Center: {x: 0.00019780235, y: 0.005824702, z: 0.0017707404}
+    m_Extent: {x: 0.00027193222, y: 0.00022873865, z: 0.0002118898}
+  m_DirtyAABB: 0
+--- !u!1 &3932023679998696943
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6637270760791400288}
+  m_Layer: 0
+  m_Name: shin.R
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &6637270760791400288
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3932023679998696943}
+  m_LocalRotation: {x: 0.5995207, y: -0.090400994, z: 0.15572037, w: 0.7798422}
+  m_LocalPosition: {x: 6.984919e-12, y: 0.0005196931, z: 4.1909514e-11}
+  m_LocalScale: {x: 0.99999994, y: 0.9999999, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 995635320910262429}
+  m_Father: {fileID: 7962682501229320312}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &4006417707421819008
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1155640887668266983}
+  m_Layer: 0
+  m_Name: forearm.R_end
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1155640887668266983
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4006417707421819008}
+  m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: -0, y: 0.0011943749, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 3838292567987109152}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &4096872828824554254
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7025723684427687055}
+  m_Layer: 0
+  m_Name: eye.L
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &7025723684427687055
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4096872828824554254}
+  m_LocalRotation: {x: 0.00000011240883, y: 0.7103837, z: 0.70381457, w: -0.00000007607591}
+  m_LocalPosition: {x: -0.0009864267, y: 0.0024029962, z: 0.0007743283}
+  m_LocalScale: {x: 1, y: 0.9999997, z: 0.9999999}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 6259286334483318099}
+  m_Father: {fileID: 3434650260761326427}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &4177356140094765272
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3871633738844993740}
+  m_Layer: 0
+  m_Name: lip.T.L
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &3871633738844993740
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4177356140094765272}
+  m_LocalRotation: {x: -0.5784457, y: 0.39886352, z: 0.42384857, w: 0.57154256}
+  m_LocalPosition: {x: 4.7945237e-10, y: 0.0011328345, z: 0.002010969}
+  m_LocalScale: {x: 1.0000001, y: 1.0000001, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 6564332047592217517}
+  m_Father: {fileID: 3434650260761326427}
+  m_RootOrder: 8
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &4177749966296184099
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2031732954974184158}
+  m_Layer: 0
+  m_Name: lid.B.R.003
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &2031732954974184158
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4177749966296184099}
+  m_LocalRotation: {x: 0.3735329, y: 0.1914363, z: 0.27704298, w: 0.8643336}
+  m_LocalPosition: {x: 1.11758706e-10, y: 0.0007302396, z: -1.8626451e-11}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 8607097588990992767}
+  m_Father: {fileID: 4637473732372620200}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &4245925768582458249
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2003040163381912285}
+  m_Layer: 0
+  m_Name: lid.B.R
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &2003040163381912285
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4245925768582458249}
+  m_LocalRotation: {x: 0.037349157, y: 0.8705874, z: -0.30158472, w: 0.38694865}
+  m_LocalPosition: {x: -5.5879353e-11, y: 0.00055898685, z: -1.862645e-10}
+  m_LocalScale: {x: 0.99999994, y: 0.99999994, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 491528560663723884}
+  m_Father: {fileID: 1611184371004493056}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &4247866445010611574
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5922780046748858856}
+  m_Layer: 0
+  m_Name: lid.T.L.003
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &5922780046748858856
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4247866445010611574}
+  m_LocalRotation: {x: -0.3445354, y: -0.3416063, z: 0.26835302, w: 0.8322182}
+  m_LocalPosition: {x: -3.0733643e-10, y: 0.00052700134, z: 0}
+  m_LocalScale: {x: 1, y: 0.99999994, z: 0.99999994}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 4588486639810444708}
+  m_Father: {fileID: 2317744451904098287}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &4424540464862119634
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 870923334678167550}
+  m_Layer: 0
+  m_Name: lip.B.L.001_end
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &870923334678167550
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4424540464862119634}
+  m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: -0, y: 0.0011203274, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 975176030087924512}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &4544707960593237691
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3434650260761326427}
+  m_Layer: 0
+  m_Name: face
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &3434650260761326427
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4544707960593237691}
+  m_LocalRotation: {x: -0.063860536, y: -3.3138845e-15, z: 0.000000015225538, w: 0.99795884}
+  m_LocalPosition: {x: -3.538554e-13, y: 0.0005504301, z: -0.0000014841929}
+  m_LocalScale: {x: 1, y: 1, z: 0.99999994}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 7855641395134033136}
+  - {fileID: 4716361704291802426}
+  - {fileID: 7025723684427687055}
+  - {fileID: 6160296006110967135}
+  - {fileID: 4811824318893303174}
+  - {fileID: 3791009844188970446}
+  - {fileID: 7538186458141369528}
+  - {fileID: 1379374467916002387}
+  - {fileID: 3871633738844993740}
+  - {fileID: 3695128100402780833}
+  m_Father: {fileID: 20865142993964904}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &4613182893701471837
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6564332047592217517}
+  m_Layer: 0
+  m_Name: lip.T.L.001
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &6564332047592217517
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4613182893701471837}
+  m_LocalRotation: {x: 0.008019886, y: 0.10555382, z: 0.11037009, w: 0.9882371}
+  m_LocalPosition: {x: 3.7252902e-11, y: 0.0005741662, z: -4.3422915e-10}
+  m_LocalScale: {x: 0.9999999, y: 0.99999994, z: 0.9999998}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 5122901852405498607}
+  m_Father: {fileID: 3871633738844993740}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &4645929828929457966
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2475552407399262431}
+  m_Layer: 0
+  m_Name: tail.001
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &2475552407399262431
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4645929828929457966}
+  m_LocalRotation: {x: 0.22496065, y: -1.4582858e-14, z: -0.000000053634807, w: 0.97436786}
+  m_LocalPosition: {x: -0, y: 0.0013680662, z: 1.11758706e-10}
+  m_LocalScale: {x: 1, y: 1.0000001, z: 1.0000001}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 6377510050095406218}
+  m_Father: {fileID: 2814128027687768141}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &4930629094435573431
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4637473732372620200}
+  m_Layer: 0
+  m_Name: lid.B.R.002
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &4637473732372620200
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4930629094435573431}
+  m_LocalRotation: {x: 0.29188073, y: 0.113145515, z: 0.20411728, w: 0.9275451}
+  m_LocalPosition: {x: -2.7939677e-11, y: 0.0006454675, z: -4.86616e-10}
+  m_LocalScale: {x: 0.99999994, y: 1.0000001, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 2031732954974184158}
+  m_Father: {fileID: 491528560663723884}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &4950582815925574538
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7621218117233582883}
+  m_Layer: 0
+  m_Name: lip.T.R.001_end
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &7621218117233582883
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4950582815925574538}
+  m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: -0, y: 0.00090538635, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 5636246135290840368}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &4978996921372219741
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7855641395134033136}
+  m_Layer: 0
+  m_Name: ear.L
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &7855641395134033136
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4978996921372219741}
+  m_LocalRotation: {x: -0.3261685, y: 0.20642436, z: 0.5410612, w: 0.74716526}
+  m_LocalPosition: {x: -0.0022817976, y: 0.0025916488, z: -0.00064560847}
+  m_LocalScale: {x: 1, y: 0.99999994, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 7416373790098126718}
+  m_Father: {fileID: 3434650260761326427}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &5052896804102138480
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 9146235272556288709}
+  m_Layer: 0
+  m_Name: foot.L
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &9146235272556288709
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5052896804102138480}
+  m_LocalRotation: {x: -0.6583132, y: -0.057254676, z: 0.005075787, w: 0.7505464}
+  m_LocalPosition: {x: 1.178705e-10, y: 0.0016364137, z: -8.1490726e-12}
+  m_LocalScale: {x: 0.99999994, y: 0.9999999, z: 0.9999998}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 5394006323550395795}
+  m_Father: {fileID: 5159362533255290944}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &5102479367149415005
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5333863218529137871}
+  m_Layer: 0
+  m_Name: spine.003
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &5333863218529137871
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5102479367149415005}
+  m_LocalRotation: {x: -0.0038076206, y: 0.00000011920844, z: 4.5390322e-10, w: 0.9999928}
+  m_LocalPosition: {x: 3.330669e-18, y: 0.0011031888, z: 5.551115e-19}
+  m_LocalScale: {x: 1, y: 0.99999994, z: 0.9999999}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 7898737408510310671}
+  - {fileID: 4989387358061816488}
+  - {fileID: 20865142993964904}
+  m_Father: {fileID: 5207653694212286752}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &5302686708277529518
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3695128100402780833}
+  m_Layer: 0
+  m_Name: lip.T.R
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &3695128100402780833
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5302686708277529518}
+  m_LocalRotation: {x: -0.5784458, y: -0.3988634, z: -0.42384842, w: 0.57154274}
+  m_LocalPosition: {x: 4.8342785e-10, y: 0.0011328345, z: 0.002010969}
+  m_LocalScale: {x: 1, y: 0.99999994, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 5636246135290840368}
+  m_Father: {fileID: 3434650260761326427}
+  m_RootOrder: 9
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &5386754147973701196
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6294312701372281717}
+  m_Layer: 0
+  m_Name: forearm.L
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &6294312701372281717
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5386754147973701196}
+  m_LocalRotation: {x: 0.0140869925, y: 0.66807765, z: -0.047943886, w: 0.74241173}
+  m_LocalPosition: {x: 2.5145708e-10, y: 0.0011281231, z: -4.6566126e-11}
+  m_LocalScale: {x: 1, y: 1.0000001, z: 1.0000001}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 5946690229846915520}
+  m_Father: {fileID: 5459686724456291437}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &5401594648412677259
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7416373790098126718}
+  m_Layer: 0
+  m_Name: ear.L_end
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &7416373790098126718
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5401594648412677259}
+  m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: -0, y: 0.0009499521, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 7855641395134033136}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &5793284725307013210
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 995635320910262429}
+  m_Layer: 0
+  m_Name: foot.R
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &995635320910262429
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5793284725307013210}
+  m_LocalRotation: {x: -0.65831304, y: 0.05725469, z: -0.005075792, w: 0.7505465}
+  m_LocalPosition: {x: 2.0372681e-12, y: 0.0016364136, z: 5.2386893e-12}
+  m_LocalScale: {x: 0.99999994, y: 0.9999999, z: 0.99999976}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 5883694860140413182}
+  m_Father: {fileID: 6637270760791400288}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &5793290457905733029
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 19616790093322360}
+  - component: {fileID: 6461026376620872332}
+  m_Layer: 0
+  m_Name: Eye.R
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &19616790093322360
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5793290457905733029}
+  m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0.09676129, y: 0.29236382, z: 0.06942275}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 335622516012745582}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!137 &6461026376620872332
+SkinnedMeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5793290457905733029}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 3
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 5292afcaf552f4340a3f2b0cf314e22e, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  serializedVersion: 2
+  m_Quality: 0
+  m_UpdateWhenOffscreen: 0
+  m_SkinnedMotionVectors: 1
+  m_Mesh: {fileID: 9073318565304663395, guid: 1eab608e50838480cb5624ef972aaefa, type: 3}
+  m_Bones:
+  - {fileID: 634489825855426036}
+  - {fileID: 5207653694212286752}
+  - {fileID: 5333863218529137871}
+  - {fileID: 20865142993964904}
+  - {fileID: 3434650260761326427}
+  - {fileID: 3871633738844993740}
+  - {fileID: 6564332047592217517}
+  - {fileID: 7538186458141369528}
+  - {fileID: 975176030087924512}
+  - {fileID: 3695128100402780833}
+  - {fileID: 5636246135290840368}
+  - {fileID: 1379374467916002387}
+  - {fileID: 8020341672044078963}
+  - {fileID: 4811824318893303174}
+  - {fileID: 5076154694908286685}
+  - {fileID: 2317744451904098287}
+  - {fileID: 5922780046748858856}
+  - {fileID: 4588486639810444708}
+  - {fileID: 7632820076041517190}
+  - {fileID: 3211587423538233371}
+  - {fileID: 5100113213617578379}
+  - {fileID: 3791009844188970446}
+  - {fileID: 1000062606691290481}
+  - {fileID: 7646319325853042592}
+  - {fileID: 1611184371004493056}
+  - {fileID: 2003040163381912285}
+  - {fileID: 491528560663723884}
+  - {fileID: 4637473732372620200}
+  - {fileID: 2031732954974184158}
+  - {fileID: 7025723684427687055}
+  - {fileID: 6160296006110967135}
+  - {fileID: 7855641395134033136}
+  - {fileID: 4716361704291802426}
+  - {fileID: 7898737408510310671}
+  - {fileID: 5459686724456291437}
+  - {fileID: 6294312701372281717}
+  - {fileID: 4989387358061816488}
+  - {fileID: 2129881336522630087}
+  - {fileID: 3838292567987109152}
+  - {fileID: 3273720198767295813}
+  - {fileID: 5428258405080415649}
+  - {fileID: 8233220451044933438}
+  - {fileID: 5159362533255290944}
+  - {fileID: 9146235272556288709}
+  - {fileID: 7962682501229320312}
+  - {fileID: 6637270760791400288}
+  - {fileID: 995635320910262429}
+  - {fileID: 2814128027687768141}
+  - {fileID: 2475552407399262431}
+  - {fileID: 6377510050095406218}
+  m_BlendShapeWeights: []
+  m_RootBone: {fileID: 634489825855426036}
+  m_AABB:
+    m_Center: {x: 0.0009829286, y: 0.007240382, z: 0.0009981667}
+    m_Extent: {x: 0.0009534363, y: 0.00093469094, z: 0.0006723084}
+  m_DirtyAABB: 0
+--- !u!1 &6085758647815976585
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3273720198767295813}
+  m_Layer: 0
+  m_Name: pelvis.L
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &3273720198767295813
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6085758647815976585}
+  m_LocalRotation: {x: -0.42735785, y: 0.34723908, z: 0.63856053, w: 0.5376158}
+  m_LocalPosition: {x: -0.00032985624, y: 0.001645259, z: -0.000010389867}
+  m_LocalScale: {x: 1, y: 1.0000001, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 636370630179119009}
+  m_Father: {fileID: 634489825855426036}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &6141814661572711639
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 634489825855426036}
+  m_Layer: 0
+  m_Name: spine
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &634489825855426036
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6141814661572711639}
+  m_LocalRotation: {x: 0.7260651, y: -0.00000008197142, z: -0.00000008655369, w: 0.687626}
+  m_LocalPosition: {x: -1.9877398e-12, y: 0.00072087644, z: 0.0006379328}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 3273720198767295813}
+  - {fileID: 5428258405080415649}
+  - {fileID: 5207653694212286752}
+  - {fileID: 2814128027687768141}
+  - {fileID: 8233220451044933438}
+  - {fileID: 7962682501229320312}
+  m_Father: {fileID: 5798145390520151183}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &6589259992042526604
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8607097588990992767}
+  m_Layer: 0
+  m_Name: lid.B.R.003_end
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &8607097588990992767
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6589259992042526604}
+  m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: -0, y: 0.0005964784, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 2031732954974184158}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &6646484754535636260
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 636370630179119009}
+  m_Layer: 0
+  m_Name: pelvis.L_end
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &636370630179119009
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6646484754535636260}
+  m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: -0, y: 0.00089287845, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 3273720198767295813}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &6763360871382508822
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5100113213617578379}
+  m_Layer: 0
+  m_Name: lid.B.L.003
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &5100113213617578379
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6763360871382508822}
+  m_LocalRotation: {x: 0.3735329, y: -0.19143629, z: -0.27704296, w: 0.8643336}
+  m_LocalPosition: {x: -8.381903e-11, y: 0.00073023926, z: 7.45058e-10}
+  m_LocalScale: {x: 0.9999999, y: 0.9999999, z: 0.99999994}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 691341241020648536}
+  m_Father: {fileID: 3211587423538233371}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &6868215203888620322
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7632820076041517190}
+  m_Layer: 0
+  m_Name: lid.B.L.001
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &7632820076041517190
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6868215203888620322}
+  m_LocalRotation: {x: 0.50888705, y: -0.092026964, z: -0.06361405, w: 0.8535328}
+  m_LocalPosition: {x: 7.916242e-11, y: 0.00060055876, z: 7.4505804e-11}
+  m_LocalScale: {x: 1, y: 0.9999999, z: 0.99999994}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 3211587423538233371}
+  m_Father: {fileID: 4588486639810444708}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &6901500960019541483
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1928065744544838147}
+  - component: {fileID: 765177949473558178}
+  m_Layer: 0
+  m_Name: Nose
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1928065744544838147
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6901500960019541483}
+  m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: -0, y: 0.23610024, z: 0.20791784}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 335622516012745582}
+  m_RootOrder: 4
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!137 &765177949473558178
+SkinnedMeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6901500960019541483}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 3
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: a83ff704b1b4e4d3e9b2779617467156, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  serializedVersion: 2
+  m_Quality: 0
+  m_UpdateWhenOffscreen: 0
+  m_SkinnedMotionVectors: 1
+  m_Mesh: {fileID: -3284892891408679018, guid: 1eab608e50838480cb5624ef972aaefa, type: 3}
+  m_Bones:
+  - {fileID: 634489825855426036}
+  - {fileID: 5207653694212286752}
+  - {fileID: 5333863218529137871}
+  - {fileID: 20865142993964904}
+  - {fileID: 3434650260761326427}
+  - {fileID: 3871633738844993740}
+  - {fileID: 6564332047592217517}
+  - {fileID: 7538186458141369528}
+  - {fileID: 975176030087924512}
+  - {fileID: 3695128100402780833}
+  - {fileID: 5636246135290840368}
+  - {fileID: 1379374467916002387}
+  - {fileID: 8020341672044078963}
+  - {fileID: 4811824318893303174}
+  - {fileID: 5076154694908286685}
+  - {fileID: 2317744451904098287}
+  - {fileID: 5922780046748858856}
+  - {fileID: 4588486639810444708}
+  - {fileID: 7632820076041517190}
+  - {fileID: 3211587423538233371}
+  - {fileID: 5100113213617578379}
+  - {fileID: 3791009844188970446}
+  - {fileID: 1000062606691290481}
+  - {fileID: 7646319325853042592}
+  - {fileID: 1611184371004493056}
+  - {fileID: 2003040163381912285}
+  - {fileID: 491528560663723884}
+  - {fileID: 4637473732372620200}
+  - {fileID: 2031732954974184158}
+  - {fileID: 7025723684427687055}
+  - {fileID: 6160296006110967135}
+  - {fileID: 7855641395134033136}
+  - {fileID: 4716361704291802426}
+  - {fileID: 7898737408510310671}
+  - {fileID: 5459686724456291437}
+  - {fileID: 6294312701372281717}
+  - {fileID: 4989387358061816488}
+  - {fileID: 2129881336522630087}
+  - {fileID: 3838292567987109152}
+  - {fileID: 3273720198767295813}
+  - {fileID: 5428258405080415649}
+  - {fileID: 8233220451044933438}
+  - {fileID: 5159362533255290944}
+  - {fileID: 9146235272556288709}
+  - {fileID: 7962682501229320312}
+  - {fileID: 6637270760791400288}
+  - {fileID: 995635320910262429}
+  - {fileID: 2814128027687768141}
+  - {fileID: 2475552407399262431}
+  - {fileID: 6377510050095406218}
+  m_BlendShapeWeights: []
+  m_RootBone: {fileID: 634489825855426036}
+  m_AABB:
+    m_Center: {x: 0.000000014289981, y: 0.0066647823, z: 0.0024417015}
+    m_Extent: {x: 0.0006123928, y: 0.0005215155, z: 0.0005463232}
+  m_DirtyAABB: 0
+--- !u!1 &6991574828159325783
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5122901852405498607}
+  m_Layer: 0
+  m_Name: lip.T.L.001_end
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &5122901852405498607
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6991574828159325783}
+  m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: -0, y: 0.00090538635, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 6564332047592217517}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &7167736314935662671
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8251070331872120975}
+  m_Layer: 0
+  m_Name: pelvis.R_end
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &8251070331872120975
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7167736314935662671}
+  m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: -0, y: 0.00089287845, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 5428258405080415649}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &7192005733400720263
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7962682501229320312}
+  m_Layer: 0
+  m_Name: thigh.R
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &7962682501229320312
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7192005733400720263}
+  m_LocalRotation: {x: 0.76624966, y: 0.13594685, z: 0.046737272, w: 0.6262552}
+  m_LocalPosition: {x: 0.0014397519, y: 0.0014785379, z: -0.000022245466}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 6637270760791400288}
+  m_Father: {fileID: 634489825855426036}
+  m_RootOrder: 5
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &7222979466094573490
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2129881336522630087}
+  m_Layer: 0
+  m_Name: upper_arm.R
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &2129881336522630087
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7222979466094573490}
+  m_LocalRotation: {x: 0.2450199, y: 0.71380585, z: 0.011488377, w: 0.6559837}
+  m_LocalPosition: {x: -2.7939677e-11, y: 0.0009955601, z: -1.4086253e-10}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 3838292567987109152}
+  m_Father: {fileID: 4989387358061816488}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &7347807769392319097
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5428258405080415649}
+  m_Layer: 0
+  m_Name: pelvis.R
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &5428258405080415649
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7347807769392319097}
+  m_LocalRotation: {x: -0.42735797, y: -0.34723902, z: -0.63856035, w: 0.5376159}
+  m_LocalPosition: {x: 0.00032985624, y: 0.001645259, z: -0.000010390026}
+  m_LocalScale: {x: 1.0000001, y: 1.0000001, z: 0.99999994}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 8251070331872120975}
+  m_Father: {fileID: 634489825855426036}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &7433383831414560692
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 50334520836951344}
+  - component: {fileID: 5210928132942374777}
+  m_Layer: 0
+  m_Name: Tooth.002
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &50334520836951344
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7433383831414560692}
+  m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: -0.018222842, y: 0.14621697, z: 0.13672218}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 335622516012745582}
+  m_RootOrder: 8
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!137 &5210928132942374777
+SkinnedMeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7433383831414560692}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 3
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 31321ba15b8f8eb4c954353edc038b1d, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  serializedVersion: 2
+  m_Quality: 0
+  m_UpdateWhenOffscreen: 0
+  m_SkinnedMotionVectors: 1
+  m_Mesh: {fileID: 414166097793328649, guid: 1eab608e50838480cb5624ef972aaefa, type: 3}
+  m_Bones:
+  - {fileID: 634489825855426036}
+  - {fileID: 5207653694212286752}
+  - {fileID: 5333863218529137871}
+  - {fileID: 20865142993964904}
+  - {fileID: 3434650260761326427}
+  - {fileID: 3871633738844993740}
+  - {fileID: 6564332047592217517}
+  - {fileID: 7538186458141369528}
+  - {fileID: 975176030087924512}
+  - {fileID: 3695128100402780833}
+  - {fileID: 5636246135290840368}
+  - {fileID: 1379374467916002387}
+  - {fileID: 8020341672044078963}
+  - {fileID: 4811824318893303174}
+  - {fileID: 5076154694908286685}
+  - {fileID: 2317744451904098287}
+  - {fileID: 5922780046748858856}
+  - {fileID: 4588486639810444708}
+  - {fileID: 7632820076041517190}
+  - {fileID: 3211587423538233371}
+  - {fileID: 5100113213617578379}
+  - {fileID: 3791009844188970446}
+  - {fileID: 1000062606691290481}
+  - {fileID: 7646319325853042592}
+  - {fileID: 1611184371004493056}
+  - {fileID: 2003040163381912285}
+  - {fileID: 491528560663723884}
+  - {fileID: 4637473732372620200}
+  - {fileID: 2031732954974184158}
+  - {fileID: 7025723684427687055}
+  - {fileID: 6160296006110967135}
+  - {fileID: 7855641395134033136}
+  - {fileID: 4716361704291802426}
+  - {fileID: 7898737408510310671}
+  - {fileID: 5459686724456291437}
+  - {fileID: 6294312701372281717}
+  - {fileID: 4989387358061816488}
+  - {fileID: 2129881336522630087}
+  - {fileID: 3838292567987109152}
+  - {fileID: 3273720198767295813}
+  - {fileID: 5428258405080415649}
+  - {fileID: 8233220451044933438}
+  - {fileID: 5159362533255290944}
+  - {fileID: 9146235272556288709}
+  - {fileID: 7962682501229320312}
+  - {fileID: 6637270760791400288}
+  - {fileID: 995635320910262429}
+  - {fileID: 2814128027687768141}
+  - {fileID: 2475552407399262431}
+  - {fileID: 6377510050095406218}
+  m_BlendShapeWeights: []
+  m_RootBone: {fileID: 634489825855426036}
+  m_AABB:
+    m_Center: {x: -0.00022590578, y: 0.005824866, z: 0.0017707404}
+    m_Extent: {x: 0.00027193222, y: 0.00022857543, z: 0.00021188962}
+  m_DirtyAABB: 0
+--- !u!1 &7518019674743367742
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7646319325853042592}
+  m_Layer: 0
+  m_Name: lid.T.R.002
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &7646319325853042592
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7518019674743367742}
+  m_LocalRotation: {x: -0.34537932, y: 0.09603827, z: 0.06731064, w: 0.9311064}
+  m_LocalPosition: {x: 1.1641532e-10, y: 0.0005315049, z: 1.0710209e-10}
+  m_LocalScale: {x: 0.9999999, y: 0.99999994, z: 0.99999994}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 1611184371004493056}
+  m_Father: {fileID: 1000062606691290481}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &7526541525977633713
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7538186458141369528}
+  m_Layer: 0
+  m_Name: lip.B.L
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &7538186458141369528
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7526541525977633713}
+  m_LocalRotation: {x: -0.3123401, y: 0.55301946, z: 0.46602738, w: 0.6159802}
+  m_LocalPosition: {x: 2.417727e-10, y: -0.000016328106, z: 0.0010140683}
+  m_LocalScale: {x: 0.9999999, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 975176030087924512}
+  m_Father: {fileID: 3434650260761326427}
+  m_RootOrder: 6
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &7818852031063784622
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2973821386496620014}
+  - component: {fileID: 6213174791563454308}
+  m_Layer: 0
+  m_Name: Tongue
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &2973821386496620014
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7818852031063784622}
+  m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 3.4057913e-18, y: 0.121495426, z: -0.012424595}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 335622516012745582}
+  m_RootOrder: 6
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!137 &6213174791563454308
+SkinnedMeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7818852031063784622}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 3
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: a09a6ab6a56094cea95b0bd3cd0bedb0, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  serializedVersion: 2
+  m_Quality: 0
+  m_UpdateWhenOffscreen: 0
+  m_SkinnedMotionVectors: 1
+  m_Mesh: {fileID: -5657891690349177999, guid: 1eab608e50838480cb5624ef972aaefa, type: 3}
+  m_Bones:
+  - {fileID: 634489825855426036}
+  - {fileID: 5207653694212286752}
+  - {fileID: 5333863218529137871}
+  - {fileID: 20865142993964904}
+  - {fileID: 3434650260761326427}
+  - {fileID: 3871633738844993740}
+  - {fileID: 6564332047592217517}
+  - {fileID: 7538186458141369528}
+  - {fileID: 975176030087924512}
+  - {fileID: 3695128100402780833}
+  - {fileID: 5636246135290840368}
+  - {fileID: 1379374467916002387}
+  - {fileID: 8020341672044078963}
+  - {fileID: 4811824318893303174}
+  - {fileID: 5076154694908286685}
+  - {fileID: 2317744451904098287}
+  - {fileID: 5922780046748858856}
+  - {fileID: 4588486639810444708}
+  - {fileID: 7632820076041517190}
+  - {fileID: 3211587423538233371}
+  - {fileID: 5100113213617578379}
+  - {fileID: 3791009844188970446}
+  - {fileID: 1000062606691290481}
+  - {fileID: 7646319325853042592}
+  - {fileID: 1611184371004493056}
+  - {fileID: 2003040163381912285}
+  - {fileID: 491528560663723884}
+  - {fileID: 4637473732372620200}
+  - {fileID: 2031732954974184158}
+  - {fileID: 7025723684427687055}
+  - {fileID: 6160296006110967135}
+  - {fileID: 7855641395134033136}
+  - {fileID: 4716361704291802426}
+  - {fileID: 7898737408510310671}
+  - {fileID: 5459686724456291437}
+  - {fileID: 6294312701372281717}
+  - {fileID: 4989387358061816488}
+  - {fileID: 2129881336522630087}
+  - {fileID: 3838292567987109152}
+  - {fileID: 3273720198767295813}
+  - {fileID: 5428258405080415649}
+  - {fileID: 8233220451044933438}
+  - {fileID: 5159362533255290944}
+  - {fileID: 9146235272556288709}
+  - {fileID: 7962682501229320312}
+  - {fileID: 6637270760791400288}
+  - {fileID: 995635320910262429}
+  - {fileID: 2814128027687768141}
+  - {fileID: 2475552407399262431}
+  - {fileID: 6377510050095406218}
+  m_BlendShapeWeights: []
+  m_RootBone: {fileID: 634489825855426036}
+  m_AABB:
+    m_Center: {x: 4.3655746e-10, y: 0.0053361896, z: 0.00041876597}
+    m_Extent: {x: 0.00071389123, y: 0.00060901954, z: 0.0010291482}
+  m_DirtyAABB: 0
+--- !u!1 &7922678482476271577
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2814128027687768141}
+  m_Layer: 0
+  m_Name: tail
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &2814128027687768141
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7922678482476271577}
+  m_LocalRotation: {x: -0.6828127, y: -1.5470908e-14, z: 0.00000016279523, w: 0.73059344}
+  m_LocalPosition: {x: -2.5283853e-10, y: 0.0005718362, z: -0.0010604815}
+  m_LocalScale: {x: 1, y: 1.0000001, z: 1.0000001}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 2475552407399262431}
+  m_Father: {fileID: 634489825855426036}
+  m_RootOrder: 3
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &8269774531231161112
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8653288001088028898}
+  m_Layer: 0
+  m_Name: lip.B.R.001_end
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &8653288001088028898
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8269774531231161112}
+  m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: -0, y: 0.0011203274, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 8020341672044078963}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &8457962501322534814
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 491528560663723884}
+  m_Layer: 0
+  m_Name: lid.B.R.001
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &491528560663723884
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8457962501322534814}
+  m_LocalRotation: {x: 0.5088869, y: 0.09202694, z: 0.0636141, w: 0.8535329}
+  m_LocalPosition: {x: 1.2107193e-10, y: 0.00060055853, z: -1.8626451e-11}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 4637473732372620200}
+  m_Father: {fileID: 2003040163381912285}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &8547888184961301668
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5817924570505893681}
+  - component: {fileID: 8737494367712873739}
+  m_Layer: 0
+  m_Name: Tooth.001
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &5817924570505893681
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8547888184961301668}
+  m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: -0.0518128, y: 0.1459652, z: 0.13672218}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 335622516012745582}
+  m_RootOrder: 7
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!137 &8737494367712873739
+SkinnedMeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8547888184961301668}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 3
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 31321ba15b8f8eb4c954353edc038b1d, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  serializedVersion: 2
+  m_Quality: 0
+  m_UpdateWhenOffscreen: 0
+  m_SkinnedMotionVectors: 1
+  m_Mesh: {fileID: 7725083230017282717, guid: 1eab608e50838480cb5624ef972aaefa, type: 3}
+  m_Bones:
+  - {fileID: 634489825855426036}
+  - {fileID: 5207653694212286752}
+  - {fileID: 5333863218529137871}
+  - {fileID: 20865142993964904}
+  - {fileID: 3434650260761326427}
+  - {fileID: 3871633738844993740}
+  - {fileID: 6564332047592217517}
+  - {fileID: 7538186458141369528}
+  - {fileID: 975176030087924512}
+  - {fileID: 3695128100402780833}
+  - {fileID: 5636246135290840368}
+  - {fileID: 1379374467916002387}
+  - {fileID: 8020341672044078963}
+  - {fileID: 4811824318893303174}
+  - {fileID: 5076154694908286685}
+  - {fileID: 2317744451904098287}
+  - {fileID: 5922780046748858856}
+  - {fileID: 4588486639810444708}
+  - {fileID: 7632820076041517190}
+  - {fileID: 3211587423538233371}
+  - {fileID: 5100113213617578379}
+  - {fileID: 3791009844188970446}
+  - {fileID: 1000062606691290481}
+  - {fileID: 7646319325853042592}
+  - {fileID: 1611184371004493056}
+  - {fileID: 2003040163381912285}
+  - {fileID: 491528560663723884}
+  - {fileID: 4637473732372620200}
+  - {fileID: 2031732954974184158}
+  - {fileID: 7025723684427687055}
+  - {fileID: 6160296006110967135}
+  - {fileID: 7855641395134033136}
+  - {fileID: 4716361704291802426}
+  - {fileID: 7898737408510310671}
+  - {fileID: 5459686724456291437}
+  - {fileID: 6294312701372281717}
+  - {fileID: 4989387358061816488}
+  - {fileID: 2129881336522630087}
+  - {fileID: 3838292567987109152}
+  - {fileID: 3273720198767295813}
+  - {fileID: 5428258405080415649}
+  - {fileID: 8233220451044933438}
+  - {fileID: 5159362533255290944}
+  - {fileID: 9146235272556288709}
+  - {fileID: 7962682501229320312}
+  - {fileID: 6637270760791400288}
+  - {fileID: 995635320910262429}
+  - {fileID: 2814128027687768141}
+  - {fileID: 2475552407399262431}
+  - {fileID: 6377510050095406218}
+  m_BlendShapeWeights: []
+  m_RootBone: {fileID: 634489825855426036}
+  m_AABB:
+    m_Center: {x: -0.00054698344, y: 0.005843023, z: 0.0017747892}
+    m_Extent: {x: 0.00014179059, y: 0.00013210485, z: 0.000105822925}
+  m_DirtyAABB: 0
+--- !u!1 &8715503281284257810
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6160296006110967135}
+  m_Layer: 0
+  m_Name: eye.R
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &6160296006110967135
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8715503281284257810}
+  m_LocalRotation: {x: 0.00000011240883, y: 0.7103837, z: 0.70381457, w: -0.00000007607591}
+  m_LocalPosition: {x: 0.000986427, y: 0.0024029962, z: 0.0007743279}
+  m_LocalScale: {x: 1, y: 0.9999997, z: 0.9999999}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 7005886737581518621}
+  m_Father: {fileID: 3434650260761326427}
+  m_RootOrder: 3
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &8904260258226750764
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 691341241020648536}
+  m_Layer: 0
+  m_Name: lid.B.L.003_end
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &691341241020648536
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8904260258226750764}
+  m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: -0, y: 0.0005964784, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 5100113213617578379}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &9004342249602058404
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5616293758670104310}
+  - component: {fileID: 7099236278497915294}
+  m_Layer: 0
+  m_Name: Body
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &5616293758670104310
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 9004342249602058404}
+  m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: -0, y: -0.061728686, z: -0.05755474}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 335622516012745582}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!137 &7099236278497915294
+SkinnedMeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 9004342249602058404}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 3
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: cad69051e3b9445bfa19c8eba19d4ab2, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  serializedVersion: 2
+  m_Quality: 0
+  m_UpdateWhenOffscreen: 0
+  m_SkinnedMotionVectors: 1
+  m_Mesh: {fileID: 2959467708922500008, guid: 1eab608e50838480cb5624ef972aaefa, type: 3}
+  m_Bones:
+  - {fileID: 634489825855426036}
+  - {fileID: 5207653694212286752}
+  - {fileID: 5333863218529137871}
+  - {fileID: 20865142993964904}
+  - {fileID: 3434650260761326427}
+  - {fileID: 3871633738844993740}
+  - {fileID: 6564332047592217517}
+  - {fileID: 7538186458141369528}
+  - {fileID: 975176030087924512}
+  - {fileID: 3695128100402780833}
+  - {fileID: 5636246135290840368}
+  - {fileID: 1379374467916002387}
+  - {fileID: 8020341672044078963}
+  - {fileID: 4811824318893303174}
+  - {fileID: 5076154694908286685}
+  - {fileID: 2317744451904098287}
+  - {fileID: 5922780046748858856}
+  - {fileID: 4588486639810444708}
+  - {fileID: 7632820076041517190}
+  - {fileID: 3211587423538233371}
+  - {fileID: 5100113213617578379}
+  - {fileID: 3791009844188970446}
+  - {fileID: 1000062606691290481}
+  - {fileID: 7646319325853042592}
+  - {fileID: 1611184371004493056}
+  - {fileID: 2003040163381912285}
+  - {fileID: 491528560663723884}
+  - {fileID: 4637473732372620200}
+  - {fileID: 2031732954974184158}
+  - {fileID: 7025723684427687055}
+  - {fileID: 6160296006110967135}
+  - {fileID: 7855641395134033136}
+  - {fileID: 4716361704291802426}
+  - {fileID: 7898737408510310671}
+  - {fileID: 5459686724456291437}
+  - {fileID: 6294312701372281717}
+  - {fileID: 4989387358061816488}
+  - {fileID: 2129881336522630087}
+  - {fileID: 3838292567987109152}
+  - {fileID: 3273720198767295813}
+  - {fileID: 5428258405080415649}
+  - {fileID: 8233220451044933438}
+  - {fileID: 5159362533255290944}
+  - {fileID: 9146235272556288709}
+  - {fileID: 7962682501229320312}
+  - {fileID: 6637270760791400288}
+  - {fileID: 995635320910262429}
+  - {fileID: 2814128027687768141}
+  - {fileID: 2475552407399262431}
+  - {fileID: 6377510050095406218}
+  m_BlendShapeWeights: []
+  m_RootBone: {fileID: 634489825855426036}
+  m_AABB:
+    m_Center: {x: 0, y: 0.002822532, z: -0.00163412}
+    m_Extent: {x: 0.004505611, y: 0.0036249605, z: 0.0036662016}
+  m_DirtyAABB: 0
+--- !u!1 &9035842332015151411
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5883694860140413182}
+  m_Layer: 0
+  m_Name: foot.R_end
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &5883694860140413182
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 9035842332015151411}
+  m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: -0, y: 0.0010071099, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 995635320910262429}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}

--- a/RunInBoots/Assets/Resources/TitleObject/MouseObject.prefab.meta
+++ b/RunInBoots/Assets/Resources/TitleObject/MouseObject.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 6122173cc222ae94c91d74f15f3ef875
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/RunInBoots/Assets/Resources/TitleObject/OniObject.prefab
+++ b/RunInBoots/Assets/Resources/TitleObject/OniObject.prefab
@@ -1,0 +1,151 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &7615261746948767189
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7615261746948767185}
+  m_Layer: 7
+  m_Name: OniObject
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &7615261746948767185
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7615261746948767189}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 3083636834940186630}
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1001 &3261167020402939885
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 7615261746948767185}
+    m_Modifications:
+    - target: {fileID: -8679921383154817045, guid: b03263af09cff4540b8f9283bda272a5,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: b03263af09cff4540b8f9283bda272a5,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: b03263af09cff4540b8f9283bda272a5,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: b03263af09cff4540b8f9283bda272a5,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: b03263af09cff4540b8f9283bda272a5,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: b03263af09cff4540b8f9283bda272a5,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: b03263af09cff4540b8f9283bda272a5,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: b03263af09cff4540b8f9283bda272a5,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: b03263af09cff4540b8f9283bda272a5,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: b03263af09cff4540b8f9283bda272a5,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: b03263af09cff4540b8f9283bda272a5,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: b03263af09cff4540b8f9283bda272a5,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: b03263af09cff4540b8f9283bda272a5,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 180
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: b03263af09cff4540b8f9283bda272a5,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 919132149155446097, guid: b03263af09cff4540b8f9283bda272a5,
+        type: 3}
+      propertyPath: m_Name
+      value: Enemy
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: b03263af09cff4540b8f9283bda272a5, type: 3}
+--- !u!1 &2414096463901174460 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 919132149155446097, guid: b03263af09cff4540b8f9283bda272a5,
+    type: 3}
+  m_PrefabInstance: {fileID: 3261167020402939885}
+  m_PrefabAsset: {fileID: 0}
+--- !u!95 &9001801253288580383
+Animator:
+  serializedVersion: 5
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2414096463901174460}
+  m_Enabled: 1
+  m_Avatar: {fileID: 0}
+  m_Controller: {fileID: 9100000, guid: 345e0b2b546d44d71ae278ff39a18976, type: 2}
+  m_CullingMode: 0
+  m_UpdateMode: 0
+  m_ApplyRootMotion: 0
+  m_LinearVelocityBlending: 0
+  m_StabilizeFeet: 0
+  m_WarningMessage: 
+  m_HasTransformHierarchy: 1
+  m_AllowConstantClipSamplingOptimization: 1
+  m_KeepAnimatorStateOnDisable: 0
+  m_WriteDefaultValuesOnDisable: 0
+--- !u!4 &3083636834940186630 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: -8679921383154817045, guid: b03263af09cff4540b8f9283bda272a5,
+    type: 3}
+  m_PrefabInstance: {fileID: 3261167020402939885}
+  m_PrefabAsset: {fileID: 0}

--- a/RunInBoots/Assets/Resources/TitleObject/OniObject.prefab.meta
+++ b/RunInBoots/Assets/Resources/TitleObject/OniObject.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: a259ba50fb2cfe0419c481d2b29dbf31
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/RunInBoots/Assets/Scenes/TitleScene.unity
+++ b/RunInBoots/Assets/Scenes/TitleScene.unity
@@ -122,6 +122,139 @@ NavMeshSettings:
     debug:
       m_Flags: 0
   m_NavMeshData: {fileID: 0}
+--- !u!1001 &3905154
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 973873515}
+    m_Modifications:
+    - target: {fileID: 3224374250372635258, guid: 344807cc6608d81448ffd73b35f0a179,
+        type: 3}
+      propertyPath: m_Name
+      value: TowerCube_3
+      objectReference: {fileID: 0}
+    - target: {fileID: 5466672442152919246, guid: 344807cc6608d81448ffd73b35f0a179,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5466672442152919246, guid: 344807cc6608d81448ffd73b35f0a179,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -10.53
+      objectReference: {fileID: 0}
+    - target: {fileID: 5466672442152919246, guid: 344807cc6608d81448ffd73b35f0a179,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -2.2339058
+      objectReference: {fileID: 0}
+    - target: {fileID: 5466672442152919246, guid: 344807cc6608d81448ffd73b35f0a179,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 3.281702
+      objectReference: {fileID: 0}
+    - target: {fileID: 5466672442152919246, guid: 344807cc6608d81448ffd73b35f0a179,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5466672442152919246, guid: 344807cc6608d81448ffd73b35f0a179,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5466672442152919246, guid: 344807cc6608d81448ffd73b35f0a179,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5466672442152919246, guid: 344807cc6608d81448ffd73b35f0a179,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5466672442152919246, guid: 344807cc6608d81448ffd73b35f0a179,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5466672442152919246, guid: 344807cc6608d81448ffd73b35f0a179,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5466672442152919246, guid: 344807cc6608d81448ffd73b35f0a179,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 344807cc6608d81448ffd73b35f0a179, type: 3}
+--- !u!4 &36782376 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 579227948677741591, guid: b0183b9f3f522654d92f155636419015,
+    type: 3}
+  m_PrefabInstance: {fileID: 1605069656}
+  m_PrefabAsset: {fileID: 0}
+--- !u!4 &57460049 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 5466672442152919246, guid: 85f850ff0e5de804c868f3e1ad68f852,
+    type: 3}
+  m_PrefabInstance: {fileID: 1974433954}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &104933016
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 104933017}
+  m_Layer: 0
+  m_Name: Ground
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &104933017
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 104933016}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 2.8, y: 1.0194056, z: 1.4926233}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 1848485367}
+  - {fileID: 2145881909}
+  - {fileID: 1919148731}
+  - {fileID: 2126022628}
+  - {fileID: 1092451398}
+  - {fileID: 1386007680}
+  - {fileID: 1071145070}
+  - {fileID: 1107311043}
+  - {fileID: 1477469813}
+  - {fileID: 1356418790}
+  - {fileID: 1947363107}
+  - {fileID: 1963680509}
+  - {fileID: 1665037239}
+  - {fileID: 36782376}
+  - {fileID: 177055297}
+  - {fileID: 1234883716}
+  - {fileID: 1925036529}
+  - {fileID: 629590092}
+  - {fileID: 1607490272}
+  - {fileID: 1397982534}
+  - {fileID: 534906741}
+  m_Father: {fileID: 0}
+  m_RootOrder: 14
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &113907466
 GameObject:
   m_ObjectHideFlags: 0
@@ -137,7 +270,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!224 &113907467
 RectTransform:
   m_ObjectHideFlags: 0
@@ -162,6 +295,364 @@ RectTransform:
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
+--- !u!1001 &161482554
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 104933017}
+    m_Modifications:
+    - target: {fileID: 579227948677741591, guid: b0183b9f3f522654d92f155636419015,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 579227948677741591, guid: b0183b9f3f522654d92f155636419015,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 1.8835292
+      objectReference: {fileID: 0}
+    - target: {fileID: 579227948677741591, guid: b0183b9f3f522654d92f155636419015,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -7.0194054
+      objectReference: {fileID: 0}
+    - target: {fileID: 579227948677741591, guid: b0183b9f3f522654d92f155636419015,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 2.0073767
+      objectReference: {fileID: 0}
+    - target: {fileID: 579227948677741591, guid: b0183b9f3f522654d92f155636419015,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 579227948677741591, guid: b0183b9f3f522654d92f155636419015,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 579227948677741591, guid: b0183b9f3f522654d92f155636419015,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 579227948677741591, guid: b0183b9f3f522654d92f155636419015,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 579227948677741591, guid: b0183b9f3f522654d92f155636419015,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 579227948677741591, guid: b0183b9f3f522654d92f155636419015,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 579227948677741591, guid: b0183b9f3f522654d92f155636419015,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3186531326411940127, guid: b0183b9f3f522654d92f155636419015,
+        type: 3}
+      propertyPath: m_Name
+      value: IndoorDrop_5X1 (1)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: b0183b9f3f522654d92f155636419015, type: 3}
+--- !u!1001 &162257000
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 5287369822939886713, guid: ad35fbb3da8250443a319e23cbe387b7,
+        type: 3}
+      propertyPath: m_Name
+      value: CatObject
+      objectReference: {fileID: 0}
+    - target: {fileID: 5287369822939886715, guid: ad35fbb3da8250443a319e23cbe387b7,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 5287369822939886715, guid: ad35fbb3da8250443a319e23cbe387b7,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 5287369822939886715, guid: ad35fbb3da8250443a319e23cbe387b7,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 5287369822939886715, guid: ad35fbb3da8250443a319e23cbe387b7,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 5287369822939886715, guid: ad35fbb3da8250443a319e23cbe387b7,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -10.2
+      objectReference: {fileID: 0}
+    - target: {fileID: 5287369822939886715, guid: ad35fbb3da8250443a319e23cbe387b7,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 1.4
+      objectReference: {fileID: 0}
+    - target: {fileID: 5287369822939886715, guid: ad35fbb3da8250443a319e23cbe387b7,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 2.6843798
+      objectReference: {fileID: 0}
+    - target: {fileID: 5287369822939886715, guid: ad35fbb3da8250443a319e23cbe387b7,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.98277795
+      objectReference: {fileID: 0}
+    - target: {fileID: 5287369822939886715, guid: ad35fbb3da8250443a319e23cbe387b7,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5287369822939886715, guid: ad35fbb3da8250443a319e23cbe387b7,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0.18479025
+      objectReference: {fileID: 0}
+    - target: {fileID: 5287369822939886715, guid: ad35fbb3da8250443a319e23cbe387b7,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5287369822939886715, guid: ad35fbb3da8250443a319e23cbe387b7,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5287369822939886715, guid: ad35fbb3da8250443a319e23cbe387b7,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 21.298
+      objectReference: {fileID: 0}
+    - target: {fileID: 5287369822939886715, guid: ad35fbb3da8250443a319e23cbe387b7,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: ad35fbb3da8250443a319e23cbe387b7, type: 3}
+--- !u!4 &177055297 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 579227948677741591, guid: b0183b9f3f522654d92f155636419015,
+    type: 3}
+  m_PrefabInstance: {fileID: 1325870061}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &189537464
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 189537467}
+  - component: {fileID: 189537466}
+  - component: {fileID: 189537465}
+  m_Layer: 0
+  m_Name: Directional Light (1)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &189537465
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 189537464}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 474bcb49853aa07438625e644c072ee6, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Version: 1
+  m_UsePipelineSettings: 1
+  m_AdditionalLightsShadowResolutionTier: 2
+  m_LightLayerMask: 1
+  m_CustomShadowLayers: 0
+  m_ShadowLayerMask: 1
+  m_LightCookieSize: {x: 1, y: 1}
+  m_LightCookieOffset: {x: 0, y: 0}
+--- !u!108 &189537466
+Light:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 189537464}
+  m_Enabled: 1
+  serializedVersion: 10
+  m_Type: 1
+  m_Shape: 0
+  m_Color: {r: 1, g: 0.95686275, b: 0.8392157, a: 1}
+  m_Intensity: 1
+  m_Range: 10
+  m_SpotAngle: 30
+  m_InnerSpotAngle: 21.80208
+  m_CookieSize: 10
+  m_Shadows:
+    m_Type: 2
+    m_Resolution: -1
+    m_CustomResolution: -1
+    m_Strength: 1
+    m_Bias: 0.05
+    m_NormalBias: 0.4
+    m_NearPlane: 0.2
+    m_CullingMatrixOverride:
+      e00: 1
+      e01: 0
+      e02: 0
+      e03: 0
+      e10: 0
+      e11: 1
+      e12: 0
+      e13: 0
+      e20: 0
+      e21: 0
+      e22: 1
+      e23: 0
+      e30: 0
+      e31: 0
+      e32: 0
+      e33: 1
+    m_UseCullingMatrixOverride: 0
+  m_Cookie: {fileID: 0}
+  m_DrawHalo: 0
+  m_Flare: {fileID: 0}
+  m_RenderMode: 0
+  m_CullingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_RenderingLayerMask: 1
+  m_Lightmapping: 4
+  m_LightShadowCasterMode: 0
+  m_AreaSize: {x: 1, y: 1}
+  m_BounceIntensity: 1
+  m_ColorTemperature: 6570
+  m_UseColorTemperature: 0
+  m_BoundingSphereOverride: {x: 0, y: 0, z: 0, w: 0}
+  m_UseBoundingSphereOverride: 0
+  m_UseViewFrustumForShadowCasterCull: 1
+  m_ShadowRadius: 0
+  m_ShadowAngle: 0
+--- !u!4 &189537467
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 189537464}
+  m_LocalRotation: {x: 0.40821788, y: -0.23456968, z: 0.10938163, w: 0.8754261}
+  m_LocalPosition: {x: -9.55122, y: 3, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 8
+  m_LocalEulerAnglesHint: {x: 50, y: -30, z: 0}
+--- !u!1001 &230732398
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 7615261746948767185, guid: a259ba50fb2cfe0419c481d2b29dbf31,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 4
+      objectReference: {fileID: 0}
+    - target: {fileID: 7615261746948767185, guid: a259ba50fb2cfe0419c481d2b29dbf31,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 7615261746948767185, guid: a259ba50fb2cfe0419c481d2b29dbf31,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 7615261746948767185, guid: a259ba50fb2cfe0419c481d2b29dbf31,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 7615261746948767185, guid: a259ba50fb2cfe0419c481d2b29dbf31,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 13.861122
+      objectReference: {fileID: 0}
+    - target: {fileID: 7615261746948767185, guid: a259ba50fb2cfe0419c481d2b29dbf31,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 1.4000001
+      objectReference: {fileID: 0}
+    - target: {fileID: 7615261746948767185, guid: a259ba50fb2cfe0419c481d2b29dbf31,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 9.563176
+      objectReference: {fileID: 0}
+    - target: {fileID: 7615261746948767185, guid: a259ba50fb2cfe0419c481d2b29dbf31,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.95563745
+      objectReference: {fileID: 0}
+    - target: {fileID: 7615261746948767185, guid: a259ba50fb2cfe0419c481d2b29dbf31,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.0005910139
+      objectReference: {fileID: 0}
+    - target: {fileID: 7615261746948767185, guid: a259ba50fb2cfe0419c481d2b29dbf31,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0.29454446
+      objectReference: {fileID: 0}
+    - target: {fileID: 7615261746948767185, guid: a259ba50fb2cfe0419c481d2b29dbf31,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0.00056931627
+      objectReference: {fileID: 0}
+    - target: {fileID: 7615261746948767185, guid: a259ba50fb2cfe0419c481d2b29dbf31,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0.084
+      objectReference: {fileID: 0}
+    - target: {fileID: 7615261746948767185, guid: a259ba50fb2cfe0419c481d2b29dbf31,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 34.26
+      objectReference: {fileID: 0}
+    - target: {fileID: 7615261746948767185, guid: a259ba50fb2cfe0419c481d2b29dbf31,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: -0.042
+      objectReference: {fileID: 0}
+    - target: {fileID: 7615261746948767189, guid: a259ba50fb2cfe0419c481d2b29dbf31,
+        type: 3}
+      propertyPath: m_Name
+      value: OniObject
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: a259ba50fb2cfe0419c481d2b29dbf31, type: 3}
 --- !u!224 &246204839 stripped
 RectTransform:
   m_CorrespondingSourceObject: {fileID: 6148593550996567804, guid: 197ad0cbf2bcf8342ab4cfa75ff53a18,
@@ -292,6 +783,548 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 247180568}
   m_CullTransparentMesh: 1
+--- !u!1001 &284418783
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 973873515}
+    m_Modifications:
+    - target: {fileID: 3224374250372635258, guid: 48702f708df636747aefc7f4835d84a9,
+        type: 3}
+      propertyPath: m_Name
+      value: TowerCube_1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5466672442152919246, guid: 48702f708df636747aefc7f4835d84a9,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 5466672442152919246, guid: 48702f708df636747aefc7f4835d84a9,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -10.53
+      objectReference: {fileID: 0}
+    - target: {fileID: 5466672442152919246, guid: 48702f708df636747aefc7f4835d84a9,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 7.766095
+      objectReference: {fileID: 0}
+    - target: {fileID: 5466672442152919246, guid: 48702f708df636747aefc7f4835d84a9,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 3.281702
+      objectReference: {fileID: 0}
+    - target: {fileID: 5466672442152919246, guid: 48702f708df636747aefc7f4835d84a9,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5466672442152919246, guid: 48702f708df636747aefc7f4835d84a9,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5466672442152919246, guid: 48702f708df636747aefc7f4835d84a9,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5466672442152919246, guid: 48702f708df636747aefc7f4835d84a9,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5466672442152919246, guid: 48702f708df636747aefc7f4835d84a9,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5466672442152919246, guid: 48702f708df636747aefc7f4835d84a9,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5466672442152919246, guid: 48702f708df636747aefc7f4835d84a9,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 48702f708df636747aefc7f4835d84a9, type: 3}
+--- !u!1001 &335183642
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 104933017}
+    m_Modifications:
+    - target: {fileID: 579227948677741591, guid: b0183b9f3f522654d92f155636419015,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 8
+      objectReference: {fileID: 0}
+    - target: {fileID: 579227948677741591, guid: b0183b9f3f522654d92f155636419015,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -8.11647
+      objectReference: {fileID: 0}
+    - target: {fileID: 579227948677741591, guid: b0183b9f3f522654d92f155636419015,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -7.0194054
+      objectReference: {fileID: 0}
+    - target: {fileID: 579227948677741591, guid: b0183b9f3f522654d92f155636419015,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 3.0073767
+      objectReference: {fileID: 0}
+    - target: {fileID: 579227948677741591, guid: b0183b9f3f522654d92f155636419015,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 579227948677741591, guid: b0183b9f3f522654d92f155636419015,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 579227948677741591, guid: b0183b9f3f522654d92f155636419015,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 579227948677741591, guid: b0183b9f3f522654d92f155636419015,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 579227948677741591, guid: b0183b9f3f522654d92f155636419015,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 579227948677741591, guid: b0183b9f3f522654d92f155636419015,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 579227948677741591, guid: b0183b9f3f522654d92f155636419015,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3186531326411940127, guid: b0183b9f3f522654d92f155636419015,
+        type: 3}
+      propertyPath: m_Name
+      value: IndoorDrop_5X1 (9)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: b0183b9f3f522654d92f155636419015, type: 3}
+--- !u!1001 &363317466
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 104933017}
+    m_Modifications:
+    - target: {fileID: 579227948677741591, guid: b0183b9f3f522654d92f155636419015,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 579227948677741591, guid: b0183b9f3f522654d92f155636419015,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 1.8835292
+      objectReference: {fileID: 0}
+    - target: {fileID: 579227948677741591, guid: b0183b9f3f522654d92f155636419015,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -7.0194054
+      objectReference: {fileID: 0}
+    - target: {fileID: 579227948677741591, guid: b0183b9f3f522654d92f155636419015,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 3.0073767
+      objectReference: {fileID: 0}
+    - target: {fileID: 579227948677741591, guid: b0183b9f3f522654d92f155636419015,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 579227948677741591, guid: b0183b9f3f522654d92f155636419015,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 579227948677741591, guid: b0183b9f3f522654d92f155636419015,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 579227948677741591, guid: b0183b9f3f522654d92f155636419015,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 579227948677741591, guid: b0183b9f3f522654d92f155636419015,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 579227948677741591, guid: b0183b9f3f522654d92f155636419015,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 579227948677741591, guid: b0183b9f3f522654d92f155636419015,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3186531326411940127, guid: b0183b9f3f522654d92f155636419015,
+        type: 3}
+      propertyPath: m_Name
+      value: IndoorDrop_5X1 (6)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: b0183b9f3f522654d92f155636419015, type: 3}
+--- !u!4 &534906741 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 579227948677741591, guid: b0183b9f3f522654d92f155636419015,
+    type: 3}
+  m_PrefabInstance: {fileID: 1748418472}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &537944903
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 1228525238977188816, guid: e9b384e89dcc44f49a591884262b7eba,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1228525238977188816, guid: e9b384e89dcc44f49a591884262b7eba,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 8.66523
+      objectReference: {fileID: 0}
+    - target: {fileID: 1228525238977188816, guid: e9b384e89dcc44f49a591884262b7eba,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -5.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 1228525238977188816, guid: e9b384e89dcc44f49a591884262b7eba,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 4.3172235
+      objectReference: {fileID: 0}
+    - target: {fileID: 1228525238977188816, guid: e9b384e89dcc44f49a591884262b7eba,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.13294895
+      objectReference: {fileID: 0}
+    - target: {fileID: 1228525238977188816, guid: e9b384e89dcc44f49a591884262b7eba,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1228525238977188816, guid: e9b384e89dcc44f49a591884262b7eba,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0.9911229
+      objectReference: {fileID: 0}
+    - target: {fileID: 1228525238977188816, guid: e9b384e89dcc44f49a591884262b7eba,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1228525238977188816, guid: e9b384e89dcc44f49a591884262b7eba,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1228525238977188816, guid: e9b384e89dcc44f49a591884262b7eba,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 164.72
+      objectReference: {fileID: 0}
+    - target: {fileID: 1228525238977188816, guid: e9b384e89dcc44f49a591884262b7eba,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1228525238977188820, guid: e9b384e89dcc44f49a591884262b7eba,
+        type: 3}
+      propertyPath: m_Name
+      value: DogObject
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: e9b384e89dcc44f49a591884262b7eba, type: 3}
+--- !u!1001 &615403919
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 335622516012745582, guid: 6122173cc222ae94c91d74f15f3ef875,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 335622516012745582, guid: 6122173cc222ae94c91d74f15f3ef875,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 335622516012745582, guid: 6122173cc222ae94c91d74f15f3ef875,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 335622516012745582, guid: 6122173cc222ae94c91d74f15f3ef875,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 335622516012745582, guid: 6122173cc222ae94c91d74f15f3ef875,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 12.774836
+      objectReference: {fileID: 0}
+    - target: {fileID: 335622516012745582, guid: 6122173cc222ae94c91d74f15f3ef875,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -0.73
+      objectReference: {fileID: 0}
+    - target: {fileID: 335622516012745582, guid: 6122173cc222ae94c91d74f15f3ef875,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 5.437028
+      objectReference: {fileID: 0}
+    - target: {fileID: 335622516012745582, guid: 6122173cc222ae94c91d74f15f3ef875,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: -0.44605833
+      objectReference: {fileID: 0}
+    - target: {fileID: 335622516012745582, guid: 6122173cc222ae94c91d74f15f3ef875,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 335622516012745582, guid: 6122173cc222ae94c91d74f15f3ef875,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0.8950039
+      objectReference: {fileID: 0}
+    - target: {fileID: 335622516012745582, guid: 6122173cc222ae94c91d74f15f3ef875,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 335622516012745582, guid: 6122173cc222ae94c91d74f15f3ef875,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 335622516012745582, guid: 6122173cc222ae94c91d74f15f3ef875,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 232.982
+      objectReference: {fileID: 0}
+    - target: {fileID: 335622516012745582, guid: 6122173cc222ae94c91d74f15f3ef875,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 386583455891520466, guid: 6122173cc222ae94c91d74f15f3ef875,
+        type: 3}
+      propertyPath: m_Name
+      value: MouseObject
+      objectReference: {fileID: 0}
+    - target: {fileID: 2973821386496620014, guid: 6122173cc222ae94c91d74f15f3ef875,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2973821386496620014, guid: 6122173cc222ae94c91d74f15f3ef875,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2973821386496620014, guid: 6122173cc222ae94c91d74f15f3ef875,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2973821386496620014, guid: 6122173cc222ae94c91d74f15f3ef875,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 6.25
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 6122173cc222ae94c91d74f15f3ef875, type: 3}
+--- !u!4 &629590092 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 579227948677741591, guid: b0183b9f3f522654d92f155636419015,
+    type: 3}
+  m_PrefabInstance: {fileID: 1058399536}
+  m_PrefabAsset: {fileID: 0}
+--- !u!4 &662450715 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 5466672442152919246, guid: 48702f708df636747aefc7f4835d84a9,
+    type: 3}
+  m_PrefabInstance: {fileID: 284418783}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &673120970
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 104933017}
+    m_Modifications:
+    - target: {fileID: 579227948677741591, guid: b0183b9f3f522654d92f155636419015,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 11
+      objectReference: {fileID: 0}
+    - target: {fileID: 579227948677741591, guid: b0183b9f3f522654d92f155636419015,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 6.883529
+      objectReference: {fileID: 0}
+    - target: {fileID: 579227948677741591, guid: b0183b9f3f522654d92f155636419015,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -7.0194054
+      objectReference: {fileID: 0}
+    - target: {fileID: 579227948677741591, guid: b0183b9f3f522654d92f155636419015,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 2.0073767
+      objectReference: {fileID: 0}
+    - target: {fileID: 579227948677741591, guid: b0183b9f3f522654d92f155636419015,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 579227948677741591, guid: b0183b9f3f522654d92f155636419015,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 579227948677741591, guid: b0183b9f3f522654d92f155636419015,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 579227948677741591, guid: b0183b9f3f522654d92f155636419015,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 579227948677741591, guid: b0183b9f3f522654d92f155636419015,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 579227948677741591, guid: b0183b9f3f522654d92f155636419015,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 579227948677741591, guid: b0183b9f3f522654d92f155636419015,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3186531326411940127, guid: b0183b9f3f522654d92f155636419015,
+        type: 3}
+      propertyPath: m_Name
+      value: IndoorDrop_5X1
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: b0183b9f3f522654d92f155636419015, type: 3}
+--- !u!4 &687712897 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 5466672442152919246, guid: 344807cc6608d81448ffd73b35f0a179,
+    type: 3}
+  m_PrefabInstance: {fileID: 3905154}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &766740858
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 104933017}
+    m_Modifications:
+    - target: {fileID: 579227948677741591, guid: b0183b9f3f522654d92f155636419015,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 4
+      objectReference: {fileID: 0}
+    - target: {fileID: 579227948677741591, guid: b0183b9f3f522654d92f155636419015,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -18.11647
+      objectReference: {fileID: 0}
+    - target: {fileID: 579227948677741591, guid: b0183b9f3f522654d92f155636419015,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -7.0194054
+      objectReference: {fileID: 0}
+    - target: {fileID: 579227948677741591, guid: b0183b9f3f522654d92f155636419015,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 2.0073767
+      objectReference: {fileID: 0}
+    - target: {fileID: 579227948677741591, guid: b0183b9f3f522654d92f155636419015,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 579227948677741591, guid: b0183b9f3f522654d92f155636419015,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 579227948677741591, guid: b0183b9f3f522654d92f155636419015,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 579227948677741591, guid: b0183b9f3f522654d92f155636419015,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 579227948677741591, guid: b0183b9f3f522654d92f155636419015,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 579227948677741591, guid: b0183b9f3f522654d92f155636419015,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 579227948677741591, guid: b0183b9f3f522654d92f155636419015,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3186531326411940127, guid: b0183b9f3f522654d92f155636419015,
+        type: 3}
+      propertyPath: m_Name
+      value: IndoorDrop_5X1 (5)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: b0183b9f3f522654d92f155636419015, type: 3}
 --- !u!1 &792273976
 GameObject:
   m_ObjectHideFlags: 0
@@ -322,7 +1355,7 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 4
+  m_RootOrder: 12
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &792273979
 MonoBehaviour:
@@ -602,7 +1635,7 @@ RectTransform:
   - {fileID: 113907467}
   - {fileID: 813071482}
   m_Father: {fileID: 0}
-  m_RootOrder: 2
+  m_RootOrder: 9
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
@@ -946,12 +1979,12 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 948406631}
   m_LocalRotation: {x: 0.40821788, y: -0.23456968, z: 0.10938163, w: 0.8754261}
-  m_LocalPosition: {x: 0, y: 3, z: 0}
+  m_LocalPosition: {x: -9.55122, y: 3, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 1
+  m_RootOrder: 7
   m_LocalEulerAnglesHint: {x: 50, y: -30, z: 0}
 --- !u!114 &948406634
 MonoBehaviour:
@@ -1191,6 +2224,75 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1001 &954839300
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 104933017}
+    m_Modifications:
+    - target: {fileID: 579227948677741591, guid: b0183b9f3f522654d92f155636419015,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 579227948677741591, guid: b0183b9f3f522654d92f155636419015,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -3.1164708
+      objectReference: {fileID: 0}
+    - target: {fileID: 579227948677741591, guid: b0183b9f3f522654d92f155636419015,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -7.0194054
+      objectReference: {fileID: 0}
+    - target: {fileID: 579227948677741591, guid: b0183b9f3f522654d92f155636419015,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 2.0073767
+      objectReference: {fileID: 0}
+    - target: {fileID: 579227948677741591, guid: b0183b9f3f522654d92f155636419015,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 579227948677741591, guid: b0183b9f3f522654d92f155636419015,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 579227948677741591, guid: b0183b9f3f522654d92f155636419015,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 579227948677741591, guid: b0183b9f3f522654d92f155636419015,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 579227948677741591, guid: b0183b9f3f522654d92f155636419015,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 579227948677741591, guid: b0183b9f3f522654d92f155636419015,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 579227948677741591, guid: b0183b9f3f522654d92f155636419015,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3186531326411940127, guid: b0183b9f3f522654d92f155636419015,
+        type: 3}
+      propertyPath: m_Name
+      value: IndoorDrop_5X1 (2)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: b0183b9f3f522654d92f155636419015, type: 3}
 --- !u!1 &961459933
 GameObject:
   m_ObjectHideFlags: 0
@@ -1326,6 +2428,196 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 961459933}
   m_CullTransparentMesh: 1
+--- !u!1 &973873514
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 973873515}
+  m_Layer: 0
+  m_Name: Tower
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &973873515
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 973873514}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 1.25, y: -0.7, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 687712897}
+  - {fileID: 57460049}
+  - {fileID: 662450715}
+  m_Father: {fileID: 0}
+  m_RootOrder: 13
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1001 &1058399536
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 104933017}
+    m_Modifications:
+    - target: {fileID: 579227948677741591, guid: b0183b9f3f522654d92f155636419015,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 17
+      objectReference: {fileID: 0}
+    - target: {fileID: 579227948677741591, guid: b0183b9f3f522654d92f155636419015,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 6.883529
+      objectReference: {fileID: 0}
+    - target: {fileID: 579227948677741591, guid: b0183b9f3f522654d92f155636419015,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -7.0194054
+      objectReference: {fileID: 0}
+    - target: {fileID: 579227948677741591, guid: b0183b9f3f522654d92f155636419015,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 4.0073767
+      objectReference: {fileID: 0}
+    - target: {fileID: 579227948677741591, guid: b0183b9f3f522654d92f155636419015,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 579227948677741591, guid: b0183b9f3f522654d92f155636419015,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 579227948677741591, guid: b0183b9f3f522654d92f155636419015,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 579227948677741591, guid: b0183b9f3f522654d92f155636419015,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 579227948677741591, guid: b0183b9f3f522654d92f155636419015,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 579227948677741591, guid: b0183b9f3f522654d92f155636419015,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 579227948677741591, guid: b0183b9f3f522654d92f155636419015,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3186531326411940127, guid: b0183b9f3f522654d92f155636419015,
+        type: 3}
+      propertyPath: m_Name
+      value: IndoorDrop_5X1 (12)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: b0183b9f3f522654d92f155636419015, type: 3}
+--- !u!4 &1071145070 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 579227948677741591, guid: b0183b9f3f522654d92f155636419015,
+    type: 3}
+  m_PrefabInstance: {fileID: 363317466}
+  m_PrefabAsset: {fileID: 0}
+--- !u!4 &1092451398 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 579227948677741591, guid: b0183b9f3f522654d92f155636419015,
+    type: 3}
+  m_PrefabInstance: {fileID: 766740858}
+  m_PrefabAsset: {fileID: 0}
+--- !u!4 &1107311043 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 579227948677741591, guid: b0183b9f3f522654d92f155636419015,
+    type: 3}
+  m_PrefabInstance: {fileID: 1134765821}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1134765821
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 104933017}
+    m_Modifications:
+    - target: {fileID: 579227948677741591, guid: b0183b9f3f522654d92f155636419015,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 7
+      objectReference: {fileID: 0}
+    - target: {fileID: 579227948677741591, guid: b0183b9f3f522654d92f155636419015,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -3.1164708
+      objectReference: {fileID: 0}
+    - target: {fileID: 579227948677741591, guid: b0183b9f3f522654d92f155636419015,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -7.0194054
+      objectReference: {fileID: 0}
+    - target: {fileID: 579227948677741591, guid: b0183b9f3f522654d92f155636419015,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 3.0073767
+      objectReference: {fileID: 0}
+    - target: {fileID: 579227948677741591, guid: b0183b9f3f522654d92f155636419015,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 579227948677741591, guid: b0183b9f3f522654d92f155636419015,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 579227948677741591, guid: b0183b9f3f522654d92f155636419015,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 579227948677741591, guid: b0183b9f3f522654d92f155636419015,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 579227948677741591, guid: b0183b9f3f522654d92f155636419015,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 579227948677741591, guid: b0183b9f3f522654d92f155636419015,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 579227948677741591, guid: b0183b9f3f522654d92f155636419015,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3186531326411940127, guid: b0183b9f3f522654d92f155636419015,
+        type: 3}
+      propertyPath: m_Name
+      value: IndoorDrop_5X1 (8)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: b0183b9f3f522654d92f155636419015, type: 3}
 --- !u!1001 &1140038622
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -1562,6 +2854,383 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!1001 &1149349582
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 104933017}
+    m_Modifications:
+    - target: {fileID: 579227948677741591, guid: b0183b9f3f522654d92f155636419015,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 12
+      objectReference: {fileID: 0}
+    - target: {fileID: 579227948677741591, guid: b0183b9f3f522654d92f155636419015,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -18.11647
+      objectReference: {fileID: 0}
+    - target: {fileID: 579227948677741591, guid: b0183b9f3f522654d92f155636419015,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -7.0194054
+      objectReference: {fileID: 0}
+    - target: {fileID: 579227948677741591, guid: b0183b9f3f522654d92f155636419015,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 4.0073767
+      objectReference: {fileID: 0}
+    - target: {fileID: 579227948677741591, guid: b0183b9f3f522654d92f155636419015,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 579227948677741591, guid: b0183b9f3f522654d92f155636419015,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 579227948677741591, guid: b0183b9f3f522654d92f155636419015,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 579227948677741591, guid: b0183b9f3f522654d92f155636419015,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 579227948677741591, guid: b0183b9f3f522654d92f155636419015,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 579227948677741591, guid: b0183b9f3f522654d92f155636419015,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 579227948677741591, guid: b0183b9f3f522654d92f155636419015,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3186531326411940127, guid: b0183b9f3f522654d92f155636419015,
+        type: 3}
+      propertyPath: m_Name
+      value: IndoorDrop_5X1 (16)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: b0183b9f3f522654d92f155636419015, type: 3}
+--- !u!1001 &1151031618
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 104933017}
+    m_Modifications:
+    - target: {fileID: 579227948677741591, guid: b0183b9f3f522654d92f155636419015,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 18
+      objectReference: {fileID: 0}
+    - target: {fileID: 579227948677741591, guid: b0183b9f3f522654d92f155636419015,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 11.88353
+      objectReference: {fileID: 0}
+    - target: {fileID: 579227948677741591, guid: b0183b9f3f522654d92f155636419015,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -7.0194054
+      objectReference: {fileID: 0}
+    - target: {fileID: 579227948677741591, guid: b0183b9f3f522654d92f155636419015,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 2.0073767
+      objectReference: {fileID: 0}
+    - target: {fileID: 579227948677741591, guid: b0183b9f3f522654d92f155636419015,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 579227948677741591, guid: b0183b9f3f522654d92f155636419015,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 579227948677741591, guid: b0183b9f3f522654d92f155636419015,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 579227948677741591, guid: b0183b9f3f522654d92f155636419015,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 579227948677741591, guid: b0183b9f3f522654d92f155636419015,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 579227948677741591, guid: b0183b9f3f522654d92f155636419015,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 579227948677741591, guid: b0183b9f3f522654d92f155636419015,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3186531326411940127, guid: b0183b9f3f522654d92f155636419015,
+        type: 3}
+      propertyPath: m_Name
+      value: IndoorDrop_5X1 (19)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: b0183b9f3f522654d92f155636419015, type: 3}
+--- !u!4 &1234883716 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 579227948677741591, guid: b0183b9f3f522654d92f155636419015,
+    type: 3}
+  m_PrefabInstance: {fileID: 1782629954}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1260859476
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 3647897535055685554, guid: a7f7b53f29c0a3a4da75f4b06f776cc3,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -2.3056639e-19
+      objectReference: {fileID: 0}
+    - target: {fileID: 3647897535055685554, guid: a7f7b53f29c0a3a4da75f4b06f776cc3,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -0.004180998
+      objectReference: {fileID: 0}
+    - target: {fileID: 3647897535055685554, guid: a7f7b53f29c0a3a4da75f4b06f776cc3,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0.0041865166
+      objectReference: {fileID: 0}
+    - target: {fileID: 3647897535055685554, guid: a7f7b53f29c0a3a4da75f4b06f776cc3,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.798356
+      objectReference: {fileID: 0}
+    - target: {fileID: 3647897535055685554, guid: a7f7b53f29c0a3a4da75f4b06f776cc3,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0.6021857
+      objectReference: {fileID: 0}
+    - target: {fileID: 3647897535055685554, guid: a7f7b53f29c0a3a4da75f4b06f776cc3,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 3.1652536e-17
+      objectReference: {fileID: 0}
+    - target: {fileID: 3647897535055685554, guid: a7f7b53f29c0a3a4da75f4b06f776cc3,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -1.5535792e-18
+      objectReference: {fileID: 0}
+    - target: {fileID: 3647897535055685554, guid: a7f7b53f29c0a3a4da75f4b06f776cc3,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: -74.053
+      objectReference: {fileID: 0}
+    - target: {fileID: 3992559241687619214, guid: a7f7b53f29c0a3a4da75f4b06f776cc3,
+        type: 3}
+      propertyPath: m_Name
+      value: ClawObject
+      objectReference: {fileID: 0}
+    - target: {fileID: 3992559241687619215, guid: a7f7b53f29c0a3a4da75f4b06f776cc3,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 3992559241687619215, guid: a7f7b53f29c0a3a4da75f4b06f776cc3,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 3992559241687619215, guid: a7f7b53f29c0a3a4da75f4b06f776cc3,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 3992559241687619215, guid: a7f7b53f29c0a3a4da75f4b06f776cc3,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 3992559241687619215, guid: a7f7b53f29c0a3a4da75f4b06f776cc3,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 13.174836
+      objectReference: {fileID: 0}
+    - target: {fileID: 3992559241687619215, guid: a7f7b53f29c0a3a4da75f4b06f776cc3,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 4.379416
+      objectReference: {fileID: 0}
+    - target: {fileID: 3992559241687619215, guid: a7f7b53f29c0a3a4da75f4b06f776cc3,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 5.747028
+      objectReference: {fileID: 0}
+    - target: {fileID: 3992559241687619215, guid: a7f7b53f29c0a3a4da75f4b06f776cc3,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3992559241687619215, guid: a7f7b53f29c0a3a4da75f4b06f776cc3,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3992559241687619215, guid: a7f7b53f29c0a3a4da75f4b06f776cc3,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3992559241687619215, guid: a7f7b53f29c0a3a4da75f4b06f776cc3,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3992559241687619215, guid: a7f7b53f29c0a3a4da75f4b06f776cc3,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3992559241687619215, guid: a7f7b53f29c0a3a4da75f4b06f776cc3,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3992559241687619215, guid: a7f7b53f29c0a3a4da75f4b06f776cc3,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4046057203269701712, guid: a7f7b53f29c0a3a4da75f4b06f776cc3,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4046057203269701712, guid: a7f7b53f29c0a3a4da75f4b06f776cc3,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4046057203269701712, guid: a7f7b53f29c0a3a4da75f4b06f776cc3,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6739448681519347931, guid: a7f7b53f29c0a3a4da75f4b06f776cc3,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -0.042401634
+      objectReference: {fileID: 0}
+    - target: {fileID: 6739448681519347931, guid: a7f7b53f29c0a3a4da75f4b06f776cc3,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0.012683551
+      objectReference: {fileID: 0}
+    - target: {fileID: 6739448681519347931, guid: a7f7b53f29c0a3a4da75f4b06f776cc3,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.95924157
+      objectReference: {fileID: 0}
+    - target: {fileID: 6739448681519347931, guid: a7f7b53f29c0a3a4da75f4b06f776cc3,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0.28258723
+      objectReference: {fileID: 0}
+    - target: {fileID: 6739448681519347931, guid: a7f7b53f29c0a3a4da75f4b06f776cc3,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 32.829
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: a7f7b53f29c0a3a4da75f4b06f776cc3, type: 3}
+--- !u!1001 &1325870061
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 104933017}
+    m_Modifications:
+    - target: {fileID: 579227948677741591, guid: b0183b9f3f522654d92f155636419015,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 14
+      objectReference: {fileID: 0}
+    - target: {fileID: 579227948677741591, guid: b0183b9f3f522654d92f155636419015,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -8.11647
+      objectReference: {fileID: 0}
+    - target: {fileID: 579227948677741591, guid: b0183b9f3f522654d92f155636419015,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -7.0194054
+      objectReference: {fileID: 0}
+    - target: {fileID: 579227948677741591, guid: b0183b9f3f522654d92f155636419015,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 4.0073767
+      objectReference: {fileID: 0}
+    - target: {fileID: 579227948677741591, guid: b0183b9f3f522654d92f155636419015,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 579227948677741591, guid: b0183b9f3f522654d92f155636419015,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 579227948677741591, guid: b0183b9f3f522654d92f155636419015,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 579227948677741591, guid: b0183b9f3f522654d92f155636419015,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 579227948677741591, guid: b0183b9f3f522654d92f155636419015,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 579227948677741591, guid: b0183b9f3f522654d92f155636419015,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 579227948677741591, guid: b0183b9f3f522654d92f155636419015,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3186531326411940127, guid: b0183b9f3f522654d92f155636419015,
+        type: 3}
+      propertyPath: m_Name
+      value: IndoorDrop_5X1 (14)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: b0183b9f3f522654d92f155636419015, type: 3}
 --- !u!1001 &1344244141
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -1798,6 +3467,24 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!4 &1356418790 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 579227948677741591, guid: b0183b9f3f522654d92f155636419015,
+    type: 3}
+  m_PrefabInstance: {fileID: 1514429762}
+  m_PrefabAsset: {fileID: 0}
+--- !u!4 &1386007680 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 579227948677741591, guid: b0183b9f3f522654d92f155636419015,
+    type: 3}
+  m_PrefabInstance: {fileID: 1836136801}
+  m_PrefabAsset: {fileID: 0}
+--- !u!4 &1397982534 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 579227948677741591, guid: b0183b9f3f522654d92f155636419015,
+    type: 3}
+  m_PrefabInstance: {fileID: 1992251751}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &1399497846
 GameObject:
   m_ObjectHideFlags: 0
@@ -1833,7 +3520,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 2.1, y: 200}
+  m_AnchoredPosition: {x: 0, y: 150}
   m_SizeDelta: {x: 982.3, y: 286.8}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1399497848
@@ -1874,6 +3561,12 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1399497846}
   m_CullTransparentMesh: 1
+--- !u!4 &1477469813 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 579227948677741591, guid: b0183b9f3f522654d92f155636419015,
+    type: 3}
+  m_PrefabInstance: {fileID: 335183642}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &1481241116
 GameObject:
   m_ObjectHideFlags: 0
@@ -1940,8 +3633,290 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 3
+  m_RootOrder: 10
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1001 &1514429762
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 104933017}
+    m_Modifications:
+    - target: {fileID: 579227948677741591, guid: b0183b9f3f522654d92f155636419015,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 579227948677741591, guid: b0183b9f3f522654d92f155636419015,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -13.11647
+      objectReference: {fileID: 0}
+    - target: {fileID: 579227948677741591, guid: b0183b9f3f522654d92f155636419015,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -7.0194054
+      objectReference: {fileID: 0}
+    - target: {fileID: 579227948677741591, guid: b0183b9f3f522654d92f155636419015,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 3.0073767
+      objectReference: {fileID: 0}
+    - target: {fileID: 579227948677741591, guid: b0183b9f3f522654d92f155636419015,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 579227948677741591, guid: b0183b9f3f522654d92f155636419015,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 579227948677741591, guid: b0183b9f3f522654d92f155636419015,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 579227948677741591, guid: b0183b9f3f522654d92f155636419015,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 579227948677741591, guid: b0183b9f3f522654d92f155636419015,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 579227948677741591, guid: b0183b9f3f522654d92f155636419015,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 579227948677741591, guid: b0183b9f3f522654d92f155636419015,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3186531326411940127, guid: b0183b9f3f522654d92f155636419015,
+        type: 3}
+      propertyPath: m_Name
+      value: IndoorDrop_5X1 (10)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: b0183b9f3f522654d92f155636419015, type: 3}
+--- !u!1001 &1547117010
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 104933017}
+    m_Modifications:
+    - target: {fileID: 579227948677741591, guid: b0183b9f3f522654d92f155636419015,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 579227948677741591, guid: b0183b9f3f522654d92f155636419015,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -8.11647
+      objectReference: {fileID: 0}
+    - target: {fileID: 579227948677741591, guid: b0183b9f3f522654d92f155636419015,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -7.0194054
+      objectReference: {fileID: 0}
+    - target: {fileID: 579227948677741591, guid: b0183b9f3f522654d92f155636419015,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 2.0073767
+      objectReference: {fileID: 0}
+    - target: {fileID: 579227948677741591, guid: b0183b9f3f522654d92f155636419015,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 579227948677741591, guid: b0183b9f3f522654d92f155636419015,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 579227948677741591, guid: b0183b9f3f522654d92f155636419015,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 579227948677741591, guid: b0183b9f3f522654d92f155636419015,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 579227948677741591, guid: b0183b9f3f522654d92f155636419015,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 579227948677741591, guid: b0183b9f3f522654d92f155636419015,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 579227948677741591, guid: b0183b9f3f522654d92f155636419015,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3186531326411940127, guid: b0183b9f3f522654d92f155636419015,
+        type: 3}
+      propertyPath: m_Name
+      value: IndoorDrop_5X1 (3)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: b0183b9f3f522654d92f155636419015, type: 3}
+--- !u!1001 &1588661351
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 104933017}
+    m_Modifications:
+    - target: {fileID: 579227948677741591, guid: b0183b9f3f522654d92f155636419015,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 579227948677741591, guid: b0183b9f3f522654d92f155636419015,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -18.11647
+      objectReference: {fileID: 0}
+    - target: {fileID: 579227948677741591, guid: b0183b9f3f522654d92f155636419015,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -7.0194054
+      objectReference: {fileID: 0}
+    - target: {fileID: 579227948677741591, guid: b0183b9f3f522654d92f155636419015,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 3.0073767
+      objectReference: {fileID: 0}
+    - target: {fileID: 579227948677741591, guid: b0183b9f3f522654d92f155636419015,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 579227948677741591, guid: b0183b9f3f522654d92f155636419015,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 579227948677741591, guid: b0183b9f3f522654d92f155636419015,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 579227948677741591, guid: b0183b9f3f522654d92f155636419015,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 579227948677741591, guid: b0183b9f3f522654d92f155636419015,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 579227948677741591, guid: b0183b9f3f522654d92f155636419015,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 579227948677741591, guid: b0183b9f3f522654d92f155636419015,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3186531326411940127, guid: b0183b9f3f522654d92f155636419015,
+        type: 3}
+      propertyPath: m_Name
+      value: IndoorDrop_5X1 (11)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: b0183b9f3f522654d92f155636419015, type: 3}
+--- !u!1001 &1605069656
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 104933017}
+    m_Modifications:
+    - target: {fileID: 579227948677741591, guid: b0183b9f3f522654d92f155636419015,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 13
+      objectReference: {fileID: 0}
+    - target: {fileID: 579227948677741591, guid: b0183b9f3f522654d92f155636419015,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -13.11647
+      objectReference: {fileID: 0}
+    - target: {fileID: 579227948677741591, guid: b0183b9f3f522654d92f155636419015,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -7.0194054
+      objectReference: {fileID: 0}
+    - target: {fileID: 579227948677741591, guid: b0183b9f3f522654d92f155636419015,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 4.0073767
+      objectReference: {fileID: 0}
+    - target: {fileID: 579227948677741591, guid: b0183b9f3f522654d92f155636419015,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 579227948677741591, guid: b0183b9f3f522654d92f155636419015,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 579227948677741591, guid: b0183b9f3f522654d92f155636419015,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 579227948677741591, guid: b0183b9f3f522654d92f155636419015,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 579227948677741591, guid: b0183b9f3f522654d92f155636419015,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 579227948677741591, guid: b0183b9f3f522654d92f155636419015,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 579227948677741591, guid: b0183b9f3f522654d92f155636419015,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3186531326411940127, guid: b0183b9f3f522654d92f155636419015,
+        type: 3}
+      propertyPath: m_Name
+      value: IndoorDrop_5X1 (15)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: b0183b9f3f522654d92f155636419015, type: 3}
+--- !u!4 &1607490272 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 579227948677741591, guid: b0183b9f3f522654d92f155636419015,
+    type: 3}
+  m_PrefabInstance: {fileID: 1151031618}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &1627828689
 GameObject:
   m_ObjectHideFlags: 0
@@ -2018,6 +3993,165 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1627828689}
   m_CullTransparentMesh: 1
+--- !u!4 &1665037239 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 579227948677741591, guid: b0183b9f3f522654d92f155636419015,
+    type: 3}
+  m_PrefabInstance: {fileID: 1149349582}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1687946449
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 693443945601202063, guid: 65cd3a37c4f23de4698298e9edfa996a,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 5
+      objectReference: {fileID: 0}
+    - target: {fileID: 693443945601202063, guid: 65cd3a37c4f23de4698298e9edfa996a,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 693443945601202063, guid: 65cd3a37c4f23de4698298e9edfa996a,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 0.8
+      objectReference: {fileID: 0}
+    - target: {fileID: 693443945601202063, guid: 65cd3a37c4f23de4698298e9edfa996a,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 0.8
+      objectReference: {fileID: 0}
+    - target: {fileID: 693443945601202063, guid: 65cd3a37c4f23de4698298e9edfa996a,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -10.159888
+      objectReference: {fileID: 0}
+    - target: {fileID: 693443945601202063, guid: 65cd3a37c4f23de4698298e9edfa996a,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 1.1705601
+      objectReference: {fileID: 0}
+    - target: {fileID: 693443945601202063, guid: 65cd3a37c4f23de4698298e9edfa996a,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 2.25
+      objectReference: {fileID: 0}
+    - target: {fileID: 693443945601202063, guid: 65cd3a37c4f23de4698298e9edfa996a,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.98982704
+      objectReference: {fileID: 0}
+    - target: {fileID: 693443945601202063, guid: 65cd3a37c4f23de4698298e9edfa996a,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 693443945601202063, guid: 65cd3a37c4f23de4698298e9edfa996a,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0.14227621
+      objectReference: {fileID: 0}
+    - target: {fileID: 693443945601202063, guid: 65cd3a37c4f23de4698298e9edfa996a,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 693443945601202063, guid: 65cd3a37c4f23de4698298e9edfa996a,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 693443945601202063, guid: 65cd3a37c4f23de4698298e9edfa996a,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: -16.359
+      objectReference: {fileID: 0}
+    - target: {fileID: 693443945601202063, guid: 65cd3a37c4f23de4698298e9edfa996a,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3291737719317621383, guid: 65cd3a37c4f23de4698298e9edfa996a,
+        type: 3}
+      propertyPath: m_Name
+      value: CloudObject
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 65cd3a37c4f23de4698298e9edfa996a, type: 3}
+--- !u!1001 &1748418472
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 104933017}
+    m_Modifications:
+    - target: {fileID: 579227948677741591, guid: b0183b9f3f522654d92f155636419015,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 20
+      objectReference: {fileID: 0}
+    - target: {fileID: 579227948677741591, guid: b0183b9f3f522654d92f155636419015,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 11.88353
+      objectReference: {fileID: 0}
+    - target: {fileID: 579227948677741591, guid: b0183b9f3f522654d92f155636419015,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -7.0194054
+      objectReference: {fileID: 0}
+    - target: {fileID: 579227948677741591, guid: b0183b9f3f522654d92f155636419015,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 4.0073767
+      objectReference: {fileID: 0}
+    - target: {fileID: 579227948677741591, guid: b0183b9f3f522654d92f155636419015,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 579227948677741591, guid: b0183b9f3f522654d92f155636419015,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 579227948677741591, guid: b0183b9f3f522654d92f155636419015,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 579227948677741591, guid: b0183b9f3f522654d92f155636419015,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 579227948677741591, guid: b0183b9f3f522654d92f155636419015,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 579227948677741591, guid: b0183b9f3f522654d92f155636419015,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 579227948677741591, guid: b0183b9f3f522654d92f155636419015,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3186531326411940127, guid: b0183b9f3f522654d92f155636419015,
+        type: 3}
+      propertyPath: m_Name
+      value: IndoorDrop_5X1 (20)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: b0183b9f3f522654d92f155636419015, type: 3}
 --- !u!1001 &1761476797
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -2388,6 +4522,75 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1777777169}
   m_CullTransparentMesh: 1
+--- !u!1001 &1782629954
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 104933017}
+    m_Modifications:
+    - target: {fileID: 579227948677741591, guid: b0183b9f3f522654d92f155636419015,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 15
+      objectReference: {fileID: 0}
+    - target: {fileID: 579227948677741591, guid: b0183b9f3f522654d92f155636419015,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -3.1164708
+      objectReference: {fileID: 0}
+    - target: {fileID: 579227948677741591, guid: b0183b9f3f522654d92f155636419015,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -7.0194054
+      objectReference: {fileID: 0}
+    - target: {fileID: 579227948677741591, guid: b0183b9f3f522654d92f155636419015,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 4.0073767
+      objectReference: {fileID: 0}
+    - target: {fileID: 579227948677741591, guid: b0183b9f3f522654d92f155636419015,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 579227948677741591, guid: b0183b9f3f522654d92f155636419015,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 579227948677741591, guid: b0183b9f3f522654d92f155636419015,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 579227948677741591, guid: b0183b9f3f522654d92f155636419015,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 579227948677741591, guid: b0183b9f3f522654d92f155636419015,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 579227948677741591, guid: b0183b9f3f522654d92f155636419015,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 579227948677741591, guid: b0183b9f3f522654d92f155636419015,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3186531326411940127, guid: b0183b9f3f522654d92f155636419015,
+        type: 3}
+      propertyPath: m_Name
+      value: IndoorDrop_5X1 (13)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: b0183b9f3f522654d92f155636419015, type: 3}
 --- !u!1 &1815811008
 GameObject:
   m_ObjectHideFlags: 0
@@ -2429,6 +4632,93 @@ RectTransform:
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 1920, y: 200}
   m_Pivot: {x: 0.5, y: 0.5}
+--- !u!1001 &1836136801
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 104933017}
+    m_Modifications:
+    - target: {fileID: 579227948677741591, guid: b0183b9f3f522654d92f155636419015,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 5
+      objectReference: {fileID: 0}
+    - target: {fileID: 579227948677741591, guid: b0183b9f3f522654d92f155636419015,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 6.883529
+      objectReference: {fileID: 0}
+    - target: {fileID: 579227948677741591, guid: b0183b9f3f522654d92f155636419015,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -7.0194054
+      objectReference: {fileID: 0}
+    - target: {fileID: 579227948677741591, guid: b0183b9f3f522654d92f155636419015,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 3.0073767
+      objectReference: {fileID: 0}
+    - target: {fileID: 579227948677741591, guid: b0183b9f3f522654d92f155636419015,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 579227948677741591, guid: b0183b9f3f522654d92f155636419015,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 579227948677741591, guid: b0183b9f3f522654d92f155636419015,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 579227948677741591, guid: b0183b9f3f522654d92f155636419015,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 579227948677741591, guid: b0183b9f3f522654d92f155636419015,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 579227948677741591, guid: b0183b9f3f522654d92f155636419015,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 579227948677741591, guid: b0183b9f3f522654d92f155636419015,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3186531326411940127, guid: b0183b9f3f522654d92f155636419015,
+        type: 3}
+      propertyPath: m_Name
+      value: IndoorDrop_5X1 (7)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: b0183b9f3f522654d92f155636419015, type: 3}
+--- !u!4 &1848485367 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 579227948677741591, guid: b0183b9f3f522654d92f155636419015,
+    type: 3}
+  m_PrefabInstance: {fileID: 161482554}
+  m_PrefabAsset: {fileID: 0}
+--- !u!4 &1919148731 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 579227948677741591, guid: b0183b9f3f522654d92f155636419015,
+    type: 3}
+  m_PrefabInstance: {fileID: 1547117010}
+  m_PrefabAsset: {fileID: 0}
+--- !u!4 &1925036529 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 579227948677741591, guid: b0183b9f3f522654d92f155636419015,
+    type: 3}
+  m_PrefabInstance: {fileID: 1942822812}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &1941563769
 GameObject:
   m_ObjectHideFlags: 0
@@ -2551,6 +4841,75 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1941563769}
   m_CullTransparentMesh: 1
+--- !u!1001 &1942822812
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 104933017}
+    m_Modifications:
+    - target: {fileID: 579227948677741591, guid: b0183b9f3f522654d92f155636419015,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 16
+      objectReference: {fileID: 0}
+    - target: {fileID: 579227948677741591, guid: b0183b9f3f522654d92f155636419015,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 1.8835292
+      objectReference: {fileID: 0}
+    - target: {fileID: 579227948677741591, guid: b0183b9f3f522654d92f155636419015,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -7.0194054
+      objectReference: {fileID: 0}
+    - target: {fileID: 579227948677741591, guid: b0183b9f3f522654d92f155636419015,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 4.0073767
+      objectReference: {fileID: 0}
+    - target: {fileID: 579227948677741591, guid: b0183b9f3f522654d92f155636419015,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 579227948677741591, guid: b0183b9f3f522654d92f155636419015,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 579227948677741591, guid: b0183b9f3f522654d92f155636419015,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 579227948677741591, guid: b0183b9f3f522654d92f155636419015,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 579227948677741591, guid: b0183b9f3f522654d92f155636419015,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 579227948677741591, guid: b0183b9f3f522654d92f155636419015,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 579227948677741591, guid: b0183b9f3f522654d92f155636419015,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3186531326411940127, guid: b0183b9f3f522654d92f155636419015,
+        type: 3}
+      propertyPath: m_Name
+      value: IndoorDrop_5X1 (17)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: b0183b9f3f522654d92f155636419015, type: 3}
 --- !u!1001 &1947006082
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -2561,12 +4920,12 @@ PrefabInstance:
     - target: {fileID: 298229555486337133, guid: 61aa12947d65ff646ae232ed21c8403d,
         type: 3}
       propertyPath: m_RootOrder
-      value: 5
+      value: 11
       objectReference: {fileID: 0}
     - target: {fileID: 298229555486337133, guid: 61aa12947d65ff646ae232ed21c8403d,
         type: 3}
       propertyPath: m_LocalPosition.x
-      value: 18.075165
+      value: 19.36
       objectReference: {fileID: 0}
     - target: {fileID: 298229555486337133, guid: 61aa12947d65ff646ae232ed21c8403d,
         type: 3}
@@ -2576,7 +4935,7 @@ PrefabInstance:
     - target: {fileID: 298229555486337133, guid: 61aa12947d65ff646ae232ed21c8403d,
         type: 3}
       propertyPath: m_LocalPosition.z
-      value: 11.042973
+      value: 12.64
       objectReference: {fileID: 0}
     - target: {fileID: 298229555486337133, guid: 61aa12947d65ff646ae232ed21c8403d,
         type: 3}
@@ -2620,6 +4979,225 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 61aa12947d65ff646ae232ed21c8403d, type: 3}
+--- !u!4 &1947363107 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 579227948677741591, guid: b0183b9f3f522654d92f155636419015,
+    type: 3}
+  m_PrefabInstance: {fileID: 1588661351}
+  m_PrefabAsset: {fileID: 0}
+--- !u!4 &1963680509 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 579227948677741591, guid: b0183b9f3f522654d92f155636419015,
+    type: 3}
+  m_PrefabInstance: {fileID: 673120970}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1974433954
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 973873515}
+    m_Modifications:
+    - target: {fileID: 3224374250372635258, guid: 85f850ff0e5de804c868f3e1ad68f852,
+        type: 3}
+      propertyPath: m_Name
+      value: TowerCube_2
+      objectReference: {fileID: 0}
+    - target: {fileID: 5466672442152919246, guid: 85f850ff0e5de804c868f3e1ad68f852,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5466672442152919246, guid: 85f850ff0e5de804c868f3e1ad68f852,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -10.53
+      objectReference: {fileID: 0}
+    - target: {fileID: 5466672442152919246, guid: 85f850ff0e5de804c868f3e1ad68f852,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 2.7660942
+      objectReference: {fileID: 0}
+    - target: {fileID: 5466672442152919246, guid: 85f850ff0e5de804c868f3e1ad68f852,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 3.281702
+      objectReference: {fileID: 0}
+    - target: {fileID: 5466672442152919246, guid: 85f850ff0e5de804c868f3e1ad68f852,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5466672442152919246, guid: 85f850ff0e5de804c868f3e1ad68f852,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5466672442152919246, guid: 85f850ff0e5de804c868f3e1ad68f852,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5466672442152919246, guid: 85f850ff0e5de804c868f3e1ad68f852,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5466672442152919246, guid: 85f850ff0e5de804c868f3e1ad68f852,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5466672442152919246, guid: 85f850ff0e5de804c868f3e1ad68f852,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5466672442152919246, guid: 85f850ff0e5de804c868f3e1ad68f852,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 85f850ff0e5de804c868f3e1ad68f852, type: 3}
+--- !u!1001 &1992251751
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 104933017}
+    m_Modifications:
+    - target: {fileID: 579227948677741591, guid: b0183b9f3f522654d92f155636419015,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 19
+      objectReference: {fileID: 0}
+    - target: {fileID: 579227948677741591, guid: b0183b9f3f522654d92f155636419015,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 11.88353
+      objectReference: {fileID: 0}
+    - target: {fileID: 579227948677741591, guid: b0183b9f3f522654d92f155636419015,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -7.0194054
+      objectReference: {fileID: 0}
+    - target: {fileID: 579227948677741591, guid: b0183b9f3f522654d92f155636419015,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 3.0073767
+      objectReference: {fileID: 0}
+    - target: {fileID: 579227948677741591, guid: b0183b9f3f522654d92f155636419015,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 579227948677741591, guid: b0183b9f3f522654d92f155636419015,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 579227948677741591, guid: b0183b9f3f522654d92f155636419015,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 579227948677741591, guid: b0183b9f3f522654d92f155636419015,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 579227948677741591, guid: b0183b9f3f522654d92f155636419015,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 579227948677741591, guid: b0183b9f3f522654d92f155636419015,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 579227948677741591, guid: b0183b9f3f522654d92f155636419015,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3186531326411940127, guid: b0183b9f3f522654d92f155636419015,
+        type: 3}
+      propertyPath: m_Name
+      value: IndoorDrop_5X1 (18)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: b0183b9f3f522654d92f155636419015, type: 3}
+--- !u!1001 &2004735743
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 104933017}
+    m_Modifications:
+    - target: {fileID: 579227948677741591, guid: b0183b9f3f522654d92f155636419015,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 579227948677741591, guid: b0183b9f3f522654d92f155636419015,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -13.11647
+      objectReference: {fileID: 0}
+    - target: {fileID: 579227948677741591, guid: b0183b9f3f522654d92f155636419015,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -7.0194054
+      objectReference: {fileID: 0}
+    - target: {fileID: 579227948677741591, guid: b0183b9f3f522654d92f155636419015,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 2.0073767
+      objectReference: {fileID: 0}
+    - target: {fileID: 579227948677741591, guid: b0183b9f3f522654d92f155636419015,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 579227948677741591, guid: b0183b9f3f522654d92f155636419015,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 579227948677741591, guid: b0183b9f3f522654d92f155636419015,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 579227948677741591, guid: b0183b9f3f522654d92f155636419015,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 579227948677741591, guid: b0183b9f3f522654d92f155636419015,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 579227948677741591, guid: b0183b9f3f522654d92f155636419015,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 579227948677741591, guid: b0183b9f3f522654d92f155636419015,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3186531326411940127, guid: b0183b9f3f522654d92f155636419015,
+        type: 3}
+      propertyPath: m_Name
+      value: IndoorDrop_5X1 (4)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: b0183b9f3f522654d92f155636419015, type: 3}
 --- !u!1 &2123476761
 GameObject:
   m_ObjectHideFlags: 0
@@ -2754,6 +5332,12 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 2123476761}
   m_CullTransparentMesh: 1
+--- !u!4 &2126022628 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 579227948677741591, guid: b0183b9f3f522654d92f155636419015,
+    type: 3}
+  m_PrefabInstance: {fileID: 2004735743}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &2142522657
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -2990,6 +5574,12 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!4 &2145881909 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 579227948677741591, guid: b0183b9f3f522654d92f155636419015,
+    type: 3}
+  m_PrefabInstance: {fileID: 954839300}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &6148593550901952347
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/RunInBoots/Assets/Scenes/TitleScene.unity
+++ b/RunInBoots/Assets/Scenes/TitleScene.unity
@@ -270,7 +270,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 0
+  m_IsActive: 1
 --- !u!224 &113907467
 RectTransform:
   m_ObjectHideFlags: 0

--- a/RunInBoots/Assets/Scripts/Managers/OutGameManager.cs
+++ b/RunInBoots/Assets/Scripts/Managers/OutGameManager.cs
@@ -49,7 +49,7 @@ public class OutGameManager : MonoBehaviour
         {
             catnipImageList[i].color = new Color(0,0,0,0);
         }
-        Debug.Log(GameObject.FindGameObjectWithTag("HeartIconContainer").name);
+
         StageUIUtils.PlaceHeartIcons(userData.lives);
         stageSelectUI.SetActive(false);
     }


### PR DESCRIPTION
# 아웃게임 씬 개선
## PR Description
아웃게임 씬 개선. Background는 미완성 상태임.
### Changes Included
- TitleObject 폴더를 Resource에 새로 만듦. 타이틀 씬에서 사용한 프리팹은 내부 컴포넌트를 없앤 복사본으로 만들어서 해당 폴더에 저장.
### Screenshots (if UI changes were made)
![image](https://github.com/user-attachments/assets/ab5d5e05-12f2-47f8-88b0-58dd49010c2f)
---
## Additional Comments
linter.yml:
---
name: Lint
on: # yamllint disable-line rule:truthy
  push: null
  pull_request: null
permissions: {}
jobs:
  build:
    name: Lint
    runs-on: ubuntu-latest
    permissions:
      contents: read
      packages: read
      # To report GitHub Actions status checks
      statuses: write
    steps:
      - name: Checkout code
        uses: actions/checkout@v4
        with:
          # super-linter needs the full git history to get the
          # list of files that changed across commits
          fetch-depth: 0
      - name: Super-linter
        uses: super-linter/super-linter@v7.1.0 # x-release-please-version
        env:
          # To report GitHub Actions status checks
          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
