### PR TITLE
S4 b27 on/off 블록 위에서 점프 시 점프 가능여부와 무관하게 상태 바뀌는 오류 수정

### DIFF
--- a/RunInBoots/Assets/Scripts/UnitModules/TransformModule.cs
+++ b/RunInBoots/Assets/Scripts/UnitModules/TransformModule.cs
@@ -84,6 +84,7 @@ public class TransformModule : MonoBehaviour
         accelSumX = 0;
         accelSumY = 0;
         rb.velocity = new Vector3(speedX, speedY, 0);
+        UpdateJumpAllowed();
     }
 
     #region Physics Related Methods
@@ -139,12 +140,17 @@ public class TransformModule : MonoBehaviour
             {
                 groundColliders.Remove(collision.collider);
             }
-            foreach(var col in groundColliders)
-                if(col ==null)
-                    groundColliders.Remove(col);
-            if (groundColliders.Count == 0)
-                jumpAllowed = false;
+            UpdateJumpAllowed();
         }
+    }
+
+    public void UpdateJumpAllowed()
+    {
+        foreach(var col in groundColliders)
+            if(col == null || col.enabled == false)
+                groundColliders.Remove(col);
+        if(groundColliders.Count == 0)
+            jumpAllowed = false;
     }
 }
 #endregion

--- a/RunInBoots/Assets/Scripts/UnitModules/TransformModule.cs
+++ b/RunInBoots/Assets/Scripts/UnitModules/TransformModule.cs
@@ -146,9 +146,12 @@ public class TransformModule : MonoBehaviour
 
     public void UpdateJumpAllowed()
     {
+        List<Collider> toRemove = new List<Collider>();
         foreach(var col in groundColliders)
             if(col == null || col.enabled == false)
-                groundColliders.Remove(col);
+                toRemove.Add(col);
+        foreach(var col in toRemove)
+            groundColliders.Remove(col);
         if(groundColliders.Count == 0)
             jumpAllowed = false;
     }


### PR DESCRIPTION
# PR Title on/off 블록 위에서 점프 판정 수정
## Related Issue(s)
Link or reference any related issues or tickets.
## PR Description
jumpAllowed getter를 만들어 수정 시 블록의 jumpValid 판정이 먼저 불리면서 플레이어의 jumpValid가 false가 되어 on/off 블록 위에서 점프가 불가능한 오류 발생. 따라서 transform module의 update에서 jumpallowed 상태를 계속 수정하도록 코드 변경.
### Changes Included
- [ ] Added new feature(s)
- [ ] Fixed identified bug(s)
- [ ] Updated relevant documentation
### Screenshots (if UI changes were made)
Attach screenshots or GIFs of any visual changes. (Only for frontend-related changes)
### Notes for Reviewer
Any specific instructions or points to be considered by the reviewer.
---
## Reviewer Checklist
- [ ] Code is written in clean, maintainable, and idiomatic form.
- [ ] Automated test coverage is adequate.
- [ ] All existing tests pass.
- [ ] Manual testing has been performed to ensure the PR works as expected.
- [ ] Code review comments have been addressed or clarified.
---
## Additional Comments
Add any other comments or information that might be useful for the review process.
linter.yml:
---
name: Lint
on: # yamllint disable-line rule:truthy
  push: null
  pull_request: null
permissions: {}
jobs:
  build:
    name: Lint
    runs-on: ubuntu-latest
    permissions:
      contents: read
      packages: read
      # To report GitHub Actions status checks
      statuses: write
    steps:
      - name: Checkout code
        uses: actions/checkout@v4
        with:
          # super-linter needs the full git history to get the
          # list of files that changed across commits
          fetch-depth: 0
      - name: Super-linter
        uses: super-linter/super-linter@v7.1.0 # x-release-please-version
        env:
          # To report GitHub Actions status checks
          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
